### PR TITLE
Add vector shuffles

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The SIMD package provides the usual arithmetic and logical operations for SIMD v
 
 (Currently missing: `count_ones count_zeros exponent ldexp leading_ones leading_zeros significand trailing_ones trailing_zeros`, many trigonometric functions)
 
-(Also currently missing: Type conversions, reinterpretation that changes the vector size, vector shuffles, scatter/gather operations, masked load/store operations)
+(Also currently missing: Type conversions, reinterpretation that changes the vector size, scatter/gather operations, masked load/store operations)
 
 These operators and functions are always applied element-wise, i.e. they are applied to each element in parallel, yielding again a SIMD vector as result. This means that e.g. multiplying two vectors yields a vector, and comparing two vectors yields a vector of booleans. This behaviour might seem strange and slightly unusual, but corresponds to the machine instructions provided by the hardware. It is also what is usually needed to vectorize loops.
 
@@ -86,6 +86,32 @@ xs = vload(Vec{4,Float64}, arr, i)
 vstore(xs, arr, i)
 ```
 The `vload` call reads a vector of size 4 from the array, i.e. it reads `arr[i:i+3]`. Similarly, the `vstore` call writes the vector `xs` to the four array elements `arr[i:i+3]`.
+
+## Vector shuffles
+
+Vector shuffle is available through the `shufflevector` function.
+
+Example:
+```Julia
+a = Vec{4, Int32}((1,2,3,4))
+b = Vec{4, Int32}((5,6,7,8))
+mask = (2,3,4,5)
+shufflevector(a, b, Val{mask})
+Int32⟨3,4,5,6⟩
+```
+`a` and `b` must be of the same SIMD vector type. The result will be a
+SIMD vector with the same element type as `a` and `b` and the same
+length as the mask. The function must be specialized on the value of
+the mask, therefore the `Val{}` construction in the call.
+
+There is also a one operand version of the function:
+```Julia
+a = Vec{4, Int32}((1,2,3,4))
+mask = (0,3,1,2)
+shufflevector(a, Val{mask})
+Int32⟨1,4,2,3⟩
+```
+
 
 ## Representing SIMD vector types in Julia
 

--- a/README.md
+++ b/README.md
@@ -99,10 +99,13 @@ mask = (2,3,4,5)
 shufflevector(a, b, Val{mask})
 Int32⟨3,4,5,6⟩
 ```
-`a` and `b` must be of the same SIMD vector type. The result will be a
-SIMD vector with the same element type as `a` and `b` and the same
-length as the mask. The function must be specialized on the value of
-the mask, therefore the `Val{}` construction in the call.
+The mask specifies vector elements counted across `a` and `b`,
+starting at 0 to follow the LLVM convention. If you don't care about
+some of the values in the result vector, you can use the symbol
+`:undef`. `a` and `b` must be of the same SIMD vector type. The
+result will be a SIMD vector with the same element type as `a` and `b`
+and the same length as the mask. The function must be specialized on
+the value of the mask, therefore the `Val{}` construction in the call.
 
 There is also a one operand version of the function:
 ```Julia
@@ -111,7 +114,6 @@ mask = (0,3,1,2)
 shufflevector(a, Val{mask})
 Int32⟨1,4,2,3⟩
 ```
-
 
 ## Representing SIMD vector types in Julia
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -372,3 +372,28 @@ let xs = valloc(Float64, 4, 13) do i i end
     @test s === sum(xs)
     # @code_native vsum(xs, V4F64)
 end
+
+info("Vector shuffles")
+
+for T in (Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Float32,Float64)
+    a = Vec{4,T}((1,2,3,4))
+    b = Vec{4,T}((5,6,7,8))
+    @test shufflevector(a, b, Val{(2,3,4,5)}) === Vec{4,T}((3,4,5,6))
+    @test shufflevector(a, b, Val{(1,7,5,5)}) === Vec{4,T}((2,8,6,6))
+    @test shufflevector(a, b, Val{0:3}) === a
+    @test shufflevector(a, b, Val{4:7}) === b
+    @test shufflevector(a, Val{(1,0,2,3)}) === Vec{4,T}((2,1,3,4))
+    @test shufflevector(a, b, Val{(0,1,4,5,2,3,6,7)}) === Vec{8,T}((1,2,5,6,3,4,7,8))
+    @test shufflevector(shufflevector(a, b, Val{(6,:undef,0,:undef)}), Val{(0,2)}) === Vec{2,T}((7,1))
+    @test isa(shufflevector(a, Val{(:undef,:undef,:undef,:undef)}), Vec{4,T})
+    c = Vec{8,T}((1:8...))
+    d = Vec{8,T}((9:16...))
+    @test shufflevector(c, d, Val{(0,1,8,15)}) === Vec{4,T}((1,2,9,16))
+    @test shufflevector(c, d, Val{1:2:15}) === Vec{8,T}((2:2:16...))
+end
+
+let
+    a = Vec{4,Bool}((true,false,true,false))
+    b = Vec{4,Bool}((false,false,true,true))
+    @test shufflevector(a, b, Val{(2,3,4,5)}) === Vec{4,Bool}((true,false,false,false))
+end


### PR DESCRIPTION
This PR adds a shufflevector function, mapping to the LLVM shufflevector instruction. It seems to work but there are a number of design decisions and missing pieces to address, at least including:

* Should the mask be 1-based like Julia usually is or 0-based to match LLVM and low level instruction conventions?
* The one and two operand versions share most of the code but not sure how best to refactor them.
* There are no tests yet. It's not obvious how to relate shufflevector tests to the nbytes parameter in runtests.jl.
* The calling convention with `VAL{}` for the mask is not too pretty, but is there any reasonable way to avoid it?
