### PR TITLE
deprecations on v0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
-julia 0.5-
+julia 0.5
+Compat 0.9.4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 environment:
   matrix:
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,8 +11,8 @@ const nbytes = 32
 const L8 = nbytes÷4
 const L4 = nbytes÷8
 
-typealias V8I32 Vec{L8,Int32}
-typealias V4F64 Vec{L4,Float64}
+const V8I32 = Vec{L8,Int32}
+const V4F64 = Vec{L4,Float64}
 
 info("Type properties")
 


### PR DESCRIPTION
This addresses the most recent deprecations on v0.6.

I was also thinking on updating SIMD.jl to use the new `llvmcall` calling convention to call llvm intrinsics allowing us to cut down on the number of generated LLVM IR snippets. 