### PR TITLE
Rename ifelse to select.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The SIMD package provides the usual arithmetic and logical operations for SIMD v
 
 `+ - * / % ^ ! ~ & | $ << >> >>> == != < <= > >=`
 
-`abs cbrt ceil copysign cos div exp exp10 exp2 flipsign floor fma ifelse inv isfinite isinf isnan issubnormal log log10 log2 muladd rem round sign signbit sin sqrt trunc`
+`abs cbrt ceil copysign cos div exp exp10 exp2 flipsign floor fma inv isfinite isinf isnan issubnormal log log10 log2 muladd rem round select sign signbit sin sqrt trunc`
 
 (Currently missing: `count_ones count_zeros exponent ldexp leading_ones leading_zeros significand trailing_ones trailing_zeros`, many trigonometric functions)
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-Compat 0.47.0
+Compat 0.52.0

--- a/src/SIMD.jl
+++ b/src/SIMD.jl
@@ -1213,7 +1213,7 @@ function valloc(::Type{T}, N::Int, sz::Int) where T
     @assert N > 0
     @assert sz >= 0
     padding = N-1
-    mem = Vector{T}(uninitialized, sz + padding)
+    mem = Vector{T}(undef, sz + padding)
     addr = Int(pointer(mem))
     off = mod(-addr, N * sizeof(T))
     @assert mod(off, sizeof(T)) == 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using SIMD
 using Compat.Test
 using Compat: @info
-using InteractiveUtils
+using Compat.InteractiveUtils
 
 @info "Basic definitions"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -99,6 +99,7 @@ for op in (
 end
 
 ifelsebool(x,y,z) = ifelse(x>=typeof(x)(0),y,z)
+ifelsebool(x::Vec,y,z) = select(x>=typeof(x)(0),y,z)
 for op in (ifelsebool, muladd)
     @test Tuple(op(V8I32(v8i32), V8I32(v8i32b), V8I32(v8i32c))) ===
         map(op, v8i32, v8i32b, v8i32c)
@@ -208,10 +209,10 @@ for op in (
     @test op(42, V8I32(v8i32)) === op(V8I32(42), V8I32(v8i32))
     @test op(V8I32(v8i32), 42) === op(V8I32(v8i32), V8I32(42))
 end
-@test ifelse(signbit(V8I32(v8i32)), 42, V8I32(v8i32)) ===
-    ifelse(signbit(V8I32(v8i32)), V8I32(42), V8I32(v8i32))
-@test ifelse(signbit(V8I32(v8i32)), V8I32(v8i32), 42) ===
-    ifelse(signbit(V8I32(v8i32)), V8I32(v8i32), V8I32(42))
+@test select(signbit(V8I32(v8i32)), 42, V8I32(v8i32)) ===
+    select(signbit(V8I32(v8i32)), V8I32(42), V8I32(v8i32))
+@test select(signbit(V8I32(v8i32)), V8I32(v8i32), 42) ===
+    select(signbit(V8I32(v8i32)), V8I32(v8i32), V8I32(42))
 for op in (muladd,)
     @test op(42, 42, V8I32(v8i32)) ===
         op(V8I32(42), V8I32(42), V8I32(v8i32))
@@ -233,10 +234,10 @@ for op in (
     @test op(42, V4F64(v4f64)) === op(V4F64(42), V4F64(v4f64))
     @test op(V4F64(v4f64), 42) === op(V4F64(v4f64), V4F64(42))
 end
-@test ifelse(signbit(V4F64(v4f64)), 42, V4F64(v4f64)) ===
-    ifelse(signbit(V4F64(v4f64)), V4F64(42), V4F64(v4f64))
-@test ifelse(signbit(V4F64(v4f64)), V4F64(v4f64), 42) ===
-    ifelse(signbit(V4F64(v4f64)), V4F64(v4f64), V4F64(42))
+@test select(signbit(V4F64(v4f64)), 42, V4F64(v4f64)) ===
+    select(signbit(V4F64(v4f64)), V4F64(42), V4F64(v4f64))
+@test select(signbit(V4F64(v4f64)), V4F64(v4f64), 42) ===
+    select(signbit(V4F64(v4f64)), V4F64(v4f64), V4F64(42))
 for op in (fma, muladd)
     @test op(42, 42, V4F64(v4f64)) ===
         op(V4F64(42), V4F64(42), V4F64(v4f64))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using SIMD
 using Compat.Test
 using Compat: @info
+using InteractiveUtils
 
 @info "Basic definitions"
 


### PR DESCRIPTION
This attempts to solve #28 by renaming `ifelse` to `select`. Note that `Base.select` is deprecated for Julia 0.7 and expected to be removed for 1.0.
