### PR TITLE
Tests cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,12 @@
-# Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
 os:
-  - linux
   - osx
+  - linux
 julia:
-  - "0.6"
+  - 0.7
   - "1.0"
-  - "nightly"
+  - nightly
 notifications:
   email: false
-script:
-  - if [ -a .git/shallow ]; then git fetch --unshallow; fi
-  - |
-    julia -e 'if VERSION >= v"0.7.0-DEV.3630"
-                  Pkg.add("OldPkg")
-                  using Pkg
-              end
-              Pkg.clone(pwd())
-              Pkg.build("SIMD")
-              Pkg.test("SIMD"; coverage=true)'
 after_success:
-  - |
-    if [ "$TRAVIS_JULIA_VERSION" = nightly ]; then
-        julia -e 'using Pkg
-                  cd(Pkg.dir("SIMD"))
-                  Pkg.add("Coverage")
-                  using Coverage
-                  Codecov.submit(process_folder())'
-    fi
+  - julia -e 'using Pkg; Pkg.dir("SIMD"); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Explicit SIMD vectorization in Julia
 
 This package allows programmers to explicitly SIMD-vectorize their Julia code. Ideally, the compiler (Julia and LLVM) would be able to do this automatically, especially for straightforwardly written code. In practice, this does not always work (for a variety of reasons), and the programmer is often left with uncertainty as to whether the code was actually vectorized. It is usually necessary to look at the generated machine code to determine whether the compiler actually vectorized the code.
 
-By exposing SIMD vector types and corresponding operations, the programmer can explicitly vectorize their code. While this does not guaratee that the generated machine code is efficient, it relieves the compiler from determining whether it is legal to vectorize the code, deciding whether it is beneficial to do so, and rearranging the code to synthesize vector instructions.
+By exposing SIMD vector types and corresponding operations, the programmer can explicitly vectorize their code. While this does not guarantee that the generated machine code is efficient, it relieves the compiler from determining whether it is legal to vectorize the code, deciding whether it is beneficial to do so, and rearranging the code to synthesize vector instructions.
 
 Here is a simple example for a manually vectorized code that adds two arrays:
 ```Julia

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,23 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/1.0/julia-1.0-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# Uncomment the following lines to allow failures on nightly julia
+# (tests will run but not make your overall status red)
+matrix:
+   allow_failures:
+   - julia_version: nightly
 
 branches:
   only:
     - master
+    - /release-.*/
 
 notifications:
   - provider: Email
@@ -18,18 +26,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo(); VERSION >= v\"0.7.0-DEV.3630\" && using Pkg; Pkg.clone(pwd(), \"SIMD\"); Pkg.build(\"SIMD\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "VERSION >= v\"0.7.0-DEV.3630\" && using Pkg; Pkg.test(\"SIMD\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# Uncomment to support code coverage upload. Should only be enabled for packages
+# which would have coverage gaps without running on Windows
+on_success:
+   - echo "%JL_CODECOV_SCRIPT%"
+   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/SIMD.jl
+++ b/src/SIMD.jl
@@ -1,7 +1,4 @@
-__precompile__()
-
 module SIMD
-using Compat
 
 #=
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,402 +1,411 @@
 using SIMD
-using Compat.Test
-using Compat: @info
-using Compat.InteractiveUtils
+using Test, InteractiveUtils
 
-@info "Basic definitions"
+@testset "SIMD" begin
 
-# The vector we are testing. Ideally, we should be able to use any vector size
-# anywhere, but LLVM codegen bugs prevent us from doing so -- thus we make this
-# a parameter.
-const nbytes = 32
+        # The vector we are testing. Ideally, we should be able to use any vector size
+        # anywhere, but LLVM codegen bugs prevent us from doing so -- thus we make this
+        # a parameter.
+        global const nbytes = 32
 
-const L8 = nbytes÷4
-const L4 = nbytes÷8
+        global const L8 = nbytes÷4
+        global const L4 = nbytes÷8
 
-const V8I32 = Vec{L8,Int32}
-const V4F64 = Vec{L4,Float64}
+        global const V8I32 = Vec{L8,Int32}
+        global const V4F64 = Vec{L4,Float64}
 
-@info "Type properties"
-
-@test eltype(V8I32) === Int32
-@test eltype(V4F64) === Float64
-@test length(V8I32) == L8
-@test length(V4F64) == L4
-@test ndims(V8I32) == 1
-@test ndims(V4F64) == 1
-@test size(V8I32,1) == L8
-@test size(V4F64,1) == L4
-@test size(V8I32) == (L8,)
-@test size(V4F64) == (L4,)
-
-@info "Type conversion"
-
-const v8i32 = ntuple(i->Int32(ifelse(isodd(i), i, -i)), L8)
-const v4f64 = ntuple(i->Float64(ifelse(isodd(i), i, -i)), L4)
-
-@test string(V8I32(v8i32)) == "Int32⟨" * string(v8i32)[2:end-1] * "⟩"
-@test string(V4F64(v4f64)) == "Float64⟨" * string(v4f64)[2:end-1] * "⟩"
-
-@test convert(V8I32, V8I32(v8i32)) === V8I32(v8i32)
-@test convert(Vec{L8,Int64}, V8I32(v8i32)) ===
-    Vec{L8, Int64}(convert(NTuple{L8,Int64}, v8i32))
-
-@test NTuple{L8,Int32}(V8I32(v8i32)) === v8i32
-@test NTuple{L4,Float64}(V4F64(v4f64)) === v4f64
-@test Tuple(V8I32(v8i32)) === v8i32
-@test Tuple(V4F64(v4f64)) === v4f64
-
-@info "Element-wise access"
-
-for i in 1:L8
-    @test Tuple(setindex(V8I32(v8i32), 9.0, Val{i})) ===
-        ntuple(j->Int32(ifelse(j==i, 9, v8i32[j])), L8)
-    @test Tuple(setindex(V8I32(v8i32), 9.0, i)) ===
-        ntuple(j->Int32(ifelse(j==i, 9, v8i32[j])), L8)
-
-    @test V8I32(v8i32)[Val{i}] === v8i32[i]
-    @test V8I32(v8i32)[i] === v8i32[i]
-end
-@test_throws BoundsError setindex(V8I32(v8i32), 0, Val{0})
-@test_throws BoundsError setindex(V8I32(v8i32), 0, Val{L8+1})
-@test_throws BoundsError setindex(V8I32(v8i32), 0, 0)
-@test_throws BoundsError setindex(V8I32(v8i32), 0, L8+1)
-@test_throws BoundsError V8I32(v8i32)[Val{0}]
-@test_throws BoundsError V8I32(v8i32)[Val{L8+1}]
-@test_throws BoundsError V8I32(v8i32)[0]
-@test_throws BoundsError V8I32(v8i32)[L8+1]
-
-for i in 1:L4
-    @test Tuple(setindex(V4F64(v4f64), 9, Val{i})) ===
-        ntuple(j->Float64(ifelse(j==i, 9.0, v4f64[j])), L4)
-    @test Tuple(setindex(V4F64(v4f64), 9, i)) ===
-        ntuple(j->Float64(ifelse(j==i, 9.0, v4f64[j])), L4)
-
-    @test V4F64(v4f64)[Val{i}] === v4f64[i]
-    @test V4F64(v4f64)[i] === v4f64[i]
-end
-
-let
-    v0 = zero(Vec{4, Float64})
-    v1 = one(Vec{4, Float64})
-    @test sum(v0*v0) == 0.0
-    @test sum(v1*v1) == 4.0
-end
-
-@info "Integer arithmetic functions"
-
-const v8i32b = map(x->Int32(x+1), v8i32)
-const v8i32c = map(x->Int32(x*2), v8i32)
-
-notbool(x) = !(x>=typeof(x)(0))
-for op in (~, +, -, abs, notbool, sign, signbit)
-    @test Tuple(op(V8I32(v8i32))) === map(op, v8i32)
-end
-
-for op in (
-        +, -, *, ÷, %, ==, !=, <, <=, >, >=,
-        copysign, div, flipsign, max, min, rem)
-    @test Tuple(op(V8I32(v8i32), V8I32(v8i32b))) === map(op, v8i32, v8i32b)
-end
-
-vifelsebool(x,y,z) = vifelse(x>=typeof(x)(0),y,z)
-for op in (vifelsebool, muladd)
-    @test Tuple(op(V8I32(v8i32), V8I32(v8i32b), V8I32(v8i32c))) ===
-        map(op, v8i32, v8i32b, v8i32c)
-end
-
-for op in (<<, >>, >>>)
-    @test Tuple(op(V8I32(v8i32), Val{3})) === map(x->op(x,3), v8i32)
-    @test Tuple(op(V8I32(v8i32), Val{-3})) === map(x->op(x,-3), v8i32)
-    @test Tuple(op(V8I32(v8i32), 3)) === map(x->op(x,3), v8i32)
-    @test Tuple(op(V8I32(v8i32), -3)) === map(x->op(x,-3), v8i32)
-    @test Tuple(op(V8I32(v8i32), V8I32(v8i32))) === map(op, v8i32, v8i32)
-end
-
-@info "Floating point arithmetic functions"
-
-const v4f64b = map(x->Float64(x+1), v4f64)
-const v4f64c = map(x->Float64(x*2), v4f64)
-
-logabs(x) = log(abs(x))
-log10abs(x) = log10(abs(x))
-log2abs(x) = log2(abs(x))
-powi4(x) = x^4
-sqrtabs(x) = sqrt(abs(x))
-for op in (
-        +, -,
-        abs, ceil, inv, isfinite, isinf, isnan, issubnormal, floor, powi4,
-        round, sign, signbit, sqrtabs, trunc)
-    @test Tuple(op(V4F64(v4f64))) === map(op, v4f64)
-end
-function Base.isapprox(t1::Tuple,t2::Tuple)
-    length(t1)==length(t2) &&
-        all(Bool[isapprox(t1[i], t2[i]) for i in 1:length(t1)])
-end
-for op in (cos, exp, exp10, exp2, logabs, log10abs, log2abs, sin)
-    rvec = Tuple(op(V4F64(v4f64)))
-    rsca = map(op, v4f64)
-    @test typeof(rvec) === typeof(rsca)
-    @test isapprox(rvec, rsca)
-end
-
-@test isfinite(V4F64(0.0))[1]
-@test isfinite(V4F64(-0.0))[1]
-@test isfinite(V4F64(nextfloat(0.0)))[1]
-@test isfinite(V4F64(-nextfloat(0.0)))[1]
-@test isfinite(V4F64(1.0))[1]
-@test isfinite(V4F64(-1.0))[1]
-@test !isfinite(V4F64(Inf))[1]
-@test !isfinite(V4F64(-Inf))[1]
-@test !isfinite(V4F64(NaN))[1]
-
-@test !isinf(V4F64(0.0))[1]
-@test !isinf(V4F64(-0.0))[1]
-@test !isinf(V4F64(nextfloat(0.0)))[1]
-@test !isinf(V4F64(-nextfloat(0.0)))[1]
-@test !isinf(V4F64(1.0))[1]
-@test !isinf(V4F64(-1.0))[1]
-@test isinf(V4F64(Inf))[1]
-@test isinf(V4F64(-Inf))[1]
-@test !isinf(V4F64(NaN))[1]
-
-@test !isnan(V4F64(0.0))[1]
-@test !isnan(V4F64(-0.0))[1]
-@test !isnan(V4F64(nextfloat(0.0)))[1]
-@test !isnan(V4F64(-nextfloat(0.0)))[1]
-@test !isnan(V4F64(1.0))[1]
-@test !isnan(V4F64(-1.0))[1]
-@test !isnan(V4F64(Inf))[1]
-@test !isnan(V4F64(-Inf))[1]
-@test isnan(V4F64(NaN))[1]
-
-@test !issubnormal(V4F64(0.0))[1]
-@test !issubnormal(V4F64(-0.0))[1]
-@test issubnormal(V4F64(nextfloat(0.0)))[1]
-@test issubnormal(V4F64(-nextfloat(0.0)))[1]
-@test !issubnormal(V4F64(1.0))[1]
-@test !issubnormal(V4F64(-1.0))[1]
-@test !issubnormal(V4F64(Inf))[1]
-@test !issubnormal(V4F64(-Inf))[1]
-@test !issubnormal(V4F64(NaN))[1]
-
-@test !signbit(V4F64(0.0))[1]
-@test signbit(V4F64(-0.0))[1]
-@test !signbit(V4F64(nextfloat(0.0)))[1]
-@test signbit(V4F64(-nextfloat(0.0)))[1]
-@test !signbit(V4F64(1.0))[1]
-@test signbit(V4F64(-1.0))[1]
-@test !signbit(V4F64(Inf))[1]
-@test signbit(V4F64(-Inf))[1]
-@test !signbit(V4F64(NaN))[1]
-
-for op in (
-        +, -, *, /, %, ^, ==, !=, <, <=, >, >=,
-        copysign, flipsign, max, min, rem)
-    @test Tuple(op(V4F64(v4f64), V4F64(v4f64b))) === map(op, v4f64, v4f64b)
-end
-
-for op in (fma, vifelsebool, muladd)
-    @test Tuple(op(V4F64(v4f64), V4F64(v4f64b), V4F64(v4f64c))) ===
-        map(op, v4f64, v4f64b, v4f64c)
-end
-
-@info "Type promotion"
-
-for op in (
-        ==, !=, <, <=, >, >=,
-        &, |, ⊻, +, -, *, copysign, div, flipsign, max, min, rem)
-    @test op(42, V8I32(v8i32)) === op(V8I32(42), V8I32(v8i32))
-    @test op(V8I32(v8i32), 42) === op(V8I32(v8i32), V8I32(42))
-end
-@test vifelse(signbit(V8I32(v8i32)), 42, V8I32(v8i32)) ===
-    vifelse(signbit(V8I32(v8i32)), V8I32(42), V8I32(v8i32))
-@test vifelse(signbit(V8I32(v8i32)), V8I32(v8i32), 42) ===
-    vifelse(signbit(V8I32(v8i32)), V8I32(v8i32), V8I32(42))
-for op in (muladd,)
-    @test op(42, 42, V8I32(v8i32)) ===
-        op(V8I32(42), V8I32(42), V8I32(v8i32))
-    @test op(42, V8I32(v8i32), V8I32(v8i32)) ===
-        op(V8I32(42), V8I32(v8i32), V8I32(v8i32))
-    @test op(V8I32(v8i32), 42, V8I32(v8i32)) ===
-        op(V8I32(v8i32), V8I32(42), V8I32(v8i32))
-    @test op(V8I32(v8i32), V8I32(v8i32), 42) ===
-        op(V8I32(v8i32), V8I32(v8i32), V8I32(42))
-    @test op(42, V8I32(v8i32), 42) ===
-        op(V8I32(42), V8I32(v8i32), V8I32(42))
-    @test op(V8I32(v8i32), 42, 42) ===
-        op(V8I32(v8i32), V8I32(42), V8I32(42))
-end
-
-for op in (
-        ==, !=, <, <=, >, >=,
-        +, -, *, /, ^, copysign, flipsign, max, min, rem)
-    @test op(42, V4F64(v4f64)) === op(V4F64(42), V4F64(v4f64))
-    @test op(V4F64(v4f64), 42) === op(V4F64(v4f64), V4F64(42))
-end
-@test vifelse(signbit(V4F64(v4f64)), 42, V4F64(v4f64)) ===
-    vifelse(signbit(V4F64(v4f64)), V4F64(42), V4F64(v4f64))
-@test vifelse(signbit(V4F64(v4f64)), V4F64(v4f64), 42) ===
-    vifelse(signbit(V4F64(v4f64)), V4F64(v4f64), V4F64(42))
-for op in (fma, muladd)
-    @test op(42, 42, V4F64(v4f64)) ===
-        op(V4F64(42), V4F64(42), V4F64(v4f64))
-    @test op(42, V4F64(v4f64), V4F64(v4f64)) ===
-        op(V4F64(42), V4F64(v4f64), V4F64(v4f64))
-    @test op(V4F64(v4f64), 42, V4F64(v4f64)) ===
-        op(V4F64(v4f64), V4F64(42), V4F64(v4f64))
-    @test op(V4F64(v4f64), V4F64(v4f64), 42) ===
-        op(V4F64(v4f64), V4F64(v4f64), V4F64(42))
-    @test op(42, V4F64(v4f64), 42) ===
-        op(V4F64(42), V4F64(v4f64), V4F64(42))
-    @test op(V4F64(v4f64), 42, 42) ===
-        op(V4F64(v4f64), V4F64(42), V4F64(42))
-end
-
-@info "Reduction operations"
-
-for op in (maximum, minimum, sum, prod)
-    @test op(V8I32(v8i32)) === op(v8i32)
-end
-@test all(V8I32(v8i32)) == reduce(&, v8i32)
-@test any(V8I32(v8i32)) == reduce(|, v8i32)
-
-for op in (maximum, minimum, sum, prod)
-    @test op(V4F64(v4f64)) === op(v4f64)
-end
-
-@test sum(Vec{3,Float64}(1)) === 3.0
-@test prod(Vec{5,Float64}(2)) === 32.0
-
-@info "Load and store functions"
-
-const arri32 = valloc(Int32, L8, 2*L8) do i i end
-for i in 1:length(arri32)-(L8-1)
-    @test vload(V8I32, arri32, i) === V8I32(ntuple(j->i+j-1, L8))
-end
-for i in 1:L8:length(arri32)-(L8-1)
-    @test vloada(V8I32, arri32, i) === V8I32(ntuple(j->i+j-1, L8))
-end
-vstorea(V8I32(0), arri32, 1)
-vstore(V8I32(1), arri32, 2)
-for i in 1:length(arri32)
-    @test arri32[i] == if i==1 0 elseif i<=(L8+1) 1 else i end
-end
-
-const arrf64 = valloc(Float64, L4, 4*L4) do i i end
-for i in 1:length(arrf64)-(L4-1)
-    @test vload(V4F64, arrf64, i) === V4F64(ntuple(j->i+j-1, L4))
-end
-for i in 1:4:length(arrf64)-(L4-1)
-    @test vloada(V4F64, arrf64, i) === V4F64(ntuple(j->i+j-1, L4))
-end
-vstorea(V4F64(0), arrf64, 1)
-vstore(V4F64(1), arrf64, 2)
-for i in 1:length(arrf64)
-    @test arrf64[i] == if i==1 0 elseif i<=(L4+1) 1 else i end
-end
-
-@info "Real-world examples"
-
-function vadd!(xs::AbstractArray{T,1}, ys::AbstractArray{T,1},
-               ::Type{Vec{N,T}}) where {N,T}
-    @assert length(ys) == length(xs)
-    @assert length(xs) % N == 0
-    @inbounds for i in 1:N:length(xs)
-        xv = vload(Vec{N,T}, xs, i)
-        yv = vload(Vec{N,T}, ys, i)
-        xv += yv
-        vstore(xv, xs, i)
+    @testset "Type properties" begin
+        @test eltype(V8I32) === Int32
+        @test eltype(V4F64) === Float64
+        @test length(V8I32) == L8
+        @test length(V4F64) == L4
+        @test ndims(V8I32) == 1
+        @test ndims(V4F64) == 1
+        @test size(V8I32,1) == L8
+        @test size(V4F64,1) == L4
+        @test size(V8I32) == (L8,)
+        @test size(V4F64) == (L4,)
     end
-end
 
-let xs = valloc(Float64, L4, 4*L4) do i i end,
-    ys = valloc(Float64, L4, 4*L4) do i 1 end
-    vadd!(xs, ys, V4F64)
-    @test xs == Float64[i+1 for i in 1:(4*L4)]
-    # @code_native vadd!(xs, ys, V4F64)
-end
+    @testset "Type conversion" begin
 
-function vsum(xs::AbstractArray{T,1}, ::Type{Vec{N,T}}) where {N,T}
-    @assert length(xs) % N == 0
-    sv = Vec{N,T}(0)
-    @inbounds for i in 1:N:length(xs)
-        xv = vload(Vec{N,T}, xs, i)
-        sv += xv
+        global const v8i32 = ntuple(i->Int32(ifelse(isodd(i), i, -i)), L8)
+        global const v4f64 = ntuple(i->Float64(ifelse(isodd(i), i, -i)), L4)
+
+        @test string(V8I32(v8i32)) == "Int32⟨" * string(v8i32)[2:end-1] * "⟩"
+        @test string(V4F64(v4f64)) == "Float64⟨" * string(v4f64)[2:end-1] * "⟩"
+
+        @test convert(V8I32, V8I32(v8i32)) === V8I32(v8i32)
+        @test convert(Vec{L8,Int64}, V8I32(v8i32)) ===
+            Vec{L8, Int64}(convert(NTuple{L8,Int64}, v8i32))
+
+        @test NTuple{L8,Int32}(V8I32(v8i32)) === v8i32
+        @test NTuple{L4,Float64}(V4F64(v4f64)) === v4f64
+        @test Tuple(V8I32(v8i32)) === v8i32
+        @test Tuple(V4F64(v4f64)) === v4f64
     end
-    sum(sv)
-end
 
-let xs = valloc(Float64, L4, 4*L4) do i i end
-    s = vsum(xs, V4F64)
-    @test s === (x->(x^2+x)/2)(Float64(4*L4))
-    # @code_native vsum(xs, V4F64)
-end
+    @testset "Element-wise access" begin
 
-function vadd_masked!(xs::AbstractArray{T,1}, ys::AbstractArray{T,1},
-                      ::Type{Vec{N,T}}) where {N, T}
-    @assert length(ys) == length(xs)
-    limit = length(xs) - (N-1)
-    vlimit = Vec{N,Int}(let l=length(xs); (l:l+N-1...,) end)
-    @inbounds for i in 1:N:length(xs)
-        xv = vload(Vec{N,T}, xs, i)
-        yv = vload(Vec{N,T}, ys, i)
-        xv += yv
-        if i <= limit
-            vstore(xv, xs, i)
-        else
-            mask = Vec{N,Int}(i) <= vlimit
-            vstore(xv, xs, i, mask)
+        for i in 1:L8
+            @test Tuple(setindex(V8I32(v8i32), 9.0, Val{i})) ===
+                ntuple(j->Int32(ifelse(j==i, 9, v8i32[j])), L8)
+            @test Tuple(setindex(V8I32(v8i32), 9.0, i)) ===
+                ntuple(j->Int32(ifelse(j==i, 9, v8i32[j])), L8)
+
+            @test V8I32(v8i32)[Val{i}] === v8i32[i]
+            @test V8I32(v8i32)[i] === v8i32[i]
+        end
+
+        @test_throws BoundsError setindex(V8I32(v8i32), 0, Val{0})
+        @test_throws BoundsError setindex(V8I32(v8i32), 0, Val{L8+1})
+        @test_throws BoundsError setindex(V8I32(v8i32), 0, 0)
+        @test_throws BoundsError setindex(V8I32(v8i32), 0, L8+1)
+        @test_throws BoundsError V8I32(v8i32)[Val{0}]
+        @test_throws BoundsError V8I32(v8i32)[Val{L8+1}]
+        @test_throws BoundsError V8I32(v8i32)[0]
+        @test_throws BoundsError V8I32(v8i32)[L8+1]
+
+        for i in 1:L4
+            @test Tuple(setindex(V4F64(v4f64), 9, Val{i})) ===
+                ntuple(j->Float64(ifelse(j==i, 9.0, v4f64[j])), L4)
+            @test Tuple(setindex(V4F64(v4f64), 9, i)) ===
+                ntuple(j->Float64(ifelse(j==i, 9.0, v4f64[j])), L4)
+
+            @test V4F64(v4f64)[Val{i}] === v4f64[i]
+            @test V4F64(v4f64)[i] === v4f64[i]
+        end
+
+        let
+            v0 = zero(Vec{4, Float64})
+            v1 = one(Vec{4, Float64})
+            @test sum(v0*v0) == 0.0
+            @test sum(v1*v1) == 4.0
         end
     end
-end
 
-let xs = valloc(Float64, 4, 13) do i i end,
-    ys = valloc(Float64, 4, 13) do i 1 end
-    vadd_masked!(xs, ys, V4F64)
-    @test xs == Float64[i+1 for i in 1:13]
-    # @code_native vadd!(xs, ys, V4F64)
-end
+    @testset "Integer arithmetic functions" begin
 
-function vsum_masked(xs::AbstractArray{T,1}, ::Type{Vec{N,T}}) where {N,T}
-    vlimit = Vec{N,Int}(let l=length(xs); (l:l+N-1...,) end)
-    sv = Vec{N,T}(0)
-    @inbounds for i in 1:N:length(xs)
-        mask = Vec{N,Int}(i) <= vlimit
-        xv = vload(Vec{N,T}, xs, i, mask)
-        sv += xv
+        global const v8i32b = map(x->Int32(x+1), v8i32)
+        global const v8i32c = map(x->Int32(x*2), v8i32)
+
+        notbool(x) = !(x>=typeof(x)(0))
+        for op in (~, +, -, abs, notbool, sign, signbit)
+            @test Tuple(op(V8I32(v8i32))) === map(op, v8i32)
+        end
+
+        for op in (
+                +, -, *, ÷, %, ==, !=, <, <=, >, >=,
+                copysign, div, flipsign, max, min, rem)
+            @test Tuple(op(V8I32(v8i32), V8I32(v8i32b))) === map(op, v8i32, v8i32b)
+        end
+
+        global vifelsebool(x,y,z) = vifelse(x>=typeof(x)(0),y,z)
+        for op in (vifelsebool, muladd)
+            @test Tuple(op(V8I32(v8i32), V8I32(v8i32b), V8I32(v8i32c))) ===
+                map(op, v8i32, v8i32b, v8i32c)
+        end
+
+        for op in (<<, >>, >>>)
+            @test Tuple(op(V8I32(v8i32), Val{3})) === map(x->op(x,3), v8i32)
+            @test Tuple(op(V8I32(v8i32), Val{-3})) === map(x->op(x,-3), v8i32)
+            @test Tuple(op(V8I32(v8i32), 3)) === map(x->op(x,3), v8i32)
+            @test Tuple(op(V8I32(v8i32), -3)) === map(x->op(x,-3), v8i32)
+            @test Tuple(op(V8I32(v8i32), V8I32(v8i32))) === map(op, v8i32, v8i32)
+        end
     end
-    sum(sv)
-end
 
-let xs = valloc(Float64, 4, 13) do i i end
-    s = vsum_masked(xs, V4F64)
-    @code_llvm vsum(xs, V4F64)
-    @code_native vsum(xs, V4F64)
-    @test s === sum(xs)
-end
+    @testset "Floating point arithmetic functions" begin
 
-@info "Vector shuffles"
+        global const v4f64b = map(x->Float64(x+1), v4f64)
+        global const v4f64c = map(x->Float64(x*2), v4f64)
 
-for T in (Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Float32,Float64)
-    a = Vec{4,T}((1,2,3,4))
-    b = Vec{4,T}((5,6,7,8))
-    @test shufflevector(a, b, Val{(2,3,4,5)}) === Vec{4,T}((3,4,5,6))
-    @test shufflevector(a, b, Val{(1,7,5,5)}) === Vec{4,T}((2,8,6,6))
-    @test shufflevector(a, b, Val{0:3}) === a
-    @test shufflevector(a, b, Val{4:7}) === b
-    @test shufflevector(a, Val{(1,0,2,3)}) === Vec{4,T}((2,1,3,4))
-    @test shufflevector(a, b, Val{(0,1,4,5,2,3,6,7)}) === Vec{8,T}((1,2,5,6,3,4,7,8))
-    @test shufflevector(shufflevector(a, b, Val{(6,:undef,0,:undef)}), Val{(0,2)}) === Vec{2,T}((7,1))
-    @test isa(shufflevector(a, Val{(:undef,:undef,:undef,:undef)}), Vec{4,T})
-    c = Vec{8,T}((1:8...,))
-    d = Vec{8,T}((9:16...,))
-    @test shufflevector(c, d, Val{(0,1,8,15)}) === Vec{4,T}((1,2,9,16))
-    @test shufflevector(c, d, Val{1:2:15}) === Vec{8,T}((2:2:16...,))
-end
+        logabs(x) = log(abs(x))
+        log10abs(x) = log10(abs(x))
+        log2abs(x) = log2(abs(x))
+        powi4(x) = x^4
+        sqrtabs(x) = sqrt(abs(x))
+        for op in (
+                +, -,
+                abs, ceil, inv, isfinite, isinf, isnan, issubnormal, floor, powi4,
+                round, sign, signbit, sqrtabs, trunc)
+            @test Tuple(op(V4F64(v4f64))) === map(op, v4f64)
+        end
+        function Base.isapprox(t1::Tuple,t2::Tuple)
+            length(t1)==length(t2) &&
+                all(Bool[isapprox(t1[i], t2[i]) for i in 1:length(t1)])
+        end
+        for op in (cos, exp, exp10, exp2, logabs, log10abs, log2abs, sin)
+            rvec = Tuple(op(V4F64(v4f64)))
+            rsca = map(op, v4f64)
+            @test typeof(rvec) === typeof(rsca)
+            @test isapprox(rvec, rsca)
+        end
 
-let
-    a = Vec{4,Bool}((true,false,true,false))
-    b = Vec{4,Bool}((false,false,true,true))
-    @test shufflevector(a, b, Val{(2,3,4,5)}) === Vec{4,Bool}((true,false,false,false))
+        @test isfinite(V4F64(0.0))[1]
+        @test isfinite(V4F64(-0.0))[1]
+        @test isfinite(V4F64(nextfloat(0.0)))[1]
+        @test isfinite(V4F64(-nextfloat(0.0)))[1]
+        @test isfinite(V4F64(1.0))[1]
+        @test isfinite(V4F64(-1.0))[1]
+        @test !isfinite(V4F64(Inf))[1]
+        @test !isfinite(V4F64(-Inf))[1]
+        @test !isfinite(V4F64(NaN))[1]
+
+        @test !isinf(V4F64(0.0))[1]
+        @test !isinf(V4F64(-0.0))[1]
+        @test !isinf(V4F64(nextfloat(0.0)))[1]
+        @test !isinf(V4F64(-nextfloat(0.0)))[1]
+        @test !isinf(V4F64(1.0))[1]
+        @test !isinf(V4F64(-1.0))[1]
+        @test isinf(V4F64(Inf))[1]
+        @test isinf(V4F64(-Inf))[1]
+        @test !isinf(V4F64(NaN))[1]
+
+        @test !isnan(V4F64(0.0))[1]
+        @test !isnan(V4F64(-0.0))[1]
+        @test !isnan(V4F64(nextfloat(0.0)))[1]
+        @test !isnan(V4F64(-nextfloat(0.0)))[1]
+        @test !isnan(V4F64(1.0))[1]
+        @test !isnan(V4F64(-1.0))[1]
+        @test !isnan(V4F64(Inf))[1]
+        @test !isnan(V4F64(-Inf))[1]
+        @test isnan(V4F64(NaN))[1]
+
+        @test !issubnormal(V4F64(0.0))[1]
+        @test !issubnormal(V4F64(-0.0))[1]
+        @test issubnormal(V4F64(nextfloat(0.0)))[1]
+        @test issubnormal(V4F64(-nextfloat(0.0)))[1]
+        @test !issubnormal(V4F64(1.0))[1]
+        @test !issubnormal(V4F64(-1.0))[1]
+        @test !issubnormal(V4F64(Inf))[1]
+        @test !issubnormal(V4F64(-Inf))[1]
+        @test !issubnormal(V4F64(NaN))[1]
+
+        @test !signbit(V4F64(0.0))[1]
+        @test signbit(V4F64(-0.0))[1]
+        @test !signbit(V4F64(nextfloat(0.0)))[1]
+        @test signbit(V4F64(-nextfloat(0.0)))[1]
+        @test !signbit(V4F64(1.0))[1]
+        @test signbit(V4F64(-1.0))[1]
+        @test !signbit(V4F64(Inf))[1]
+        @test signbit(V4F64(-Inf))[1]
+        @test !signbit(V4F64(NaN))[1]
+
+        for op in (
+                +, -, *, /, %, ^, ==, !=, <, <=, >, >=,
+                copysign, flipsign, max, min, rem)
+            @test Tuple(op(V4F64(v4f64), V4F64(v4f64b))) === map(op, v4f64, v4f64b)
+        end
+
+        for op in (fma, vifelsebool, muladd)
+            @test Tuple(op(V4F64(v4f64), V4F64(v4f64b), V4F64(v4f64c))) ===
+                map(op, v4f64, v4f64b, v4f64c)
+        end
+    end
+
+    @testset "Type promotion" begin
+
+        for op in (
+                ==, !=, <, <=, >, >=,
+                &, |, ⊻, +, -, *, copysign, div, flipsign, max, min, rem)
+            @test op(42, V8I32(v8i32)) === op(V8I32(42), V8I32(v8i32))
+            @test op(V8I32(v8i32), 42) === op(V8I32(v8i32), V8I32(42))
+        end
+        @test vifelse(signbit(V8I32(v8i32)), 42, V8I32(v8i32)) ===
+            vifelse(signbit(V8I32(v8i32)), V8I32(42), V8I32(v8i32))
+        @test vifelse(signbit(V8I32(v8i32)), V8I32(v8i32), 42) ===
+            vifelse(signbit(V8I32(v8i32)), V8I32(v8i32), V8I32(42))
+        for op in (muladd,)
+            @test op(42, 42, V8I32(v8i32)) ===
+                op(V8I32(42), V8I32(42), V8I32(v8i32))
+            @test op(42, V8I32(v8i32), V8I32(v8i32)) ===
+                op(V8I32(42), V8I32(v8i32), V8I32(v8i32))
+            @test op(V8I32(v8i32), 42, V8I32(v8i32)) ===
+                op(V8I32(v8i32), V8I32(42), V8I32(v8i32))
+            @test op(V8I32(v8i32), V8I32(v8i32), 42) ===
+                op(V8I32(v8i32), V8I32(v8i32), V8I32(42))
+            @test op(42, V8I32(v8i32), 42) ===
+                op(V8I32(42), V8I32(v8i32), V8I32(42))
+            @test op(V8I32(v8i32), 42, 42) ===
+                op(V8I32(v8i32), V8I32(42), V8I32(42))
+        end
+
+        for op in (
+                ==, !=, <, <=, >, >=,
+                +, -, *, /, ^, copysign, flipsign, max, min, rem)
+            @test op(42, V4F64(v4f64)) === op(V4F64(42), V4F64(v4f64))
+            @test op(V4F64(v4f64), 42) === op(V4F64(v4f64), V4F64(42))
+        end
+        @test vifelse(signbit(V4F64(v4f64)), 42, V4F64(v4f64)) ===
+            vifelse(signbit(V4F64(v4f64)), V4F64(42), V4F64(v4f64))
+        @test vifelse(signbit(V4F64(v4f64)), V4F64(v4f64), 42) ===
+            vifelse(signbit(V4F64(v4f64)), V4F64(v4f64), V4F64(42))
+        for op in (fma, muladd)
+            @test op(42, 42, V4F64(v4f64)) ===
+                op(V4F64(42), V4F64(42), V4F64(v4f64))
+            @test op(42, V4F64(v4f64), V4F64(v4f64)) ===
+                op(V4F64(42), V4F64(v4f64), V4F64(v4f64))
+            @test op(V4F64(v4f64), 42, V4F64(v4f64)) ===
+                op(V4F64(v4f64), V4F64(42), V4F64(v4f64))
+            @test op(V4F64(v4f64), V4F64(v4f64), 42) ===
+                op(V4F64(v4f64), V4F64(v4f64), V4F64(42))
+            @test op(42, V4F64(v4f64), 42) ===
+                op(V4F64(42), V4F64(v4f64), V4F64(42))
+            @test op(V4F64(v4f64), 42, 42) ===
+                op(V4F64(v4f64), V4F64(42), V4F64(42))
+        end
+    end
+
+    @testset "Reduction operations" begin
+
+        for op in (maximum, minimum, sum, prod)
+            @test op(V8I32(v8i32)) === op(v8i32)
+        end
+        @test all(V8I32(v8i32)) == reduce(&, v8i32)
+        @test any(V8I32(v8i32)) == reduce(|, v8i32)
+
+        for op in (maximum, minimum, sum, prod)
+            @test op(V4F64(v4f64)) === op(v4f64)
+        end
+
+        @test sum(Vec{3,Float64}(1)) === 3.0
+        @test prod(Vec{5,Float64}(2)) === 32.0
+    end
+
+    @testset "Load and store functions" begin
+
+        global const arri32 = valloc(Int32, L8, 2*L8) do i i end
+        for i in 1:length(arri32)-(L8-1)
+            @test vload(V8I32, arri32, i) === V8I32(ntuple(j->i+j-1, L8))
+        end
+        for i in 1:L8:length(arri32)-(L8-1)
+            @test vloada(V8I32, arri32, i) === V8I32(ntuple(j->i+j-1, L8))
+        end
+        vstorea(V8I32(0), arri32, 1)
+        vstore(V8I32(1), arri32, 2)
+        for i in 1:length(arri32)
+            @test arri32[i] == if i==1 0 elseif i<=(L8+1) 1 else i end
+        end
+
+        global const arrf64 = valloc(Float64, L4, 4*L4) do i i end
+        for i in 1:length(arrf64)-(L4-1)
+            @test vload(V4F64, arrf64, i) === V4F64(ntuple(j->i+j-1, L4))
+        end
+        for i in 1:4:length(arrf64)-(L4-1)
+            @test vloada(V4F64, arrf64, i) === V4F64(ntuple(j->i+j-1, L4))
+        end
+        vstorea(V4F64(0), arrf64, 1)
+        vstore(V4F64(1), arrf64, 2)
+        for i in 1:length(arrf64)
+            @test arrf64[i] == if i==1 0 elseif i<=(L4+1) 1 else i end
+        end
+    end
+
+    @testset "Real-world examples" begin
+
+        function vadd!(xs::AbstractArray{T,1}, ys::AbstractArray{T,1},
+                       ::Type{Vec{N,T}}) where {N,T}
+            @assert length(ys) == length(xs)
+            @assert length(xs) % N == 0
+            @inbounds for i in 1:N:length(xs)
+                xv = vload(Vec{N,T}, xs, i)
+                yv = vload(Vec{N,T}, ys, i)
+                xv += yv
+                vstore(xv, xs, i)
+            end
+        end
+
+        let xs = valloc(Float64, L4, 4*L4) do i i end,
+            ys = valloc(Float64, L4, 4*L4) do i 1 end
+            vadd!(xs, ys, V4F64)
+            @test xs == Float64[i+1 for i in 1:(4*L4)]
+            # @code_native vadd!(xs, ys, V4F64)
+        end
+
+        function vsum(xs::AbstractArray{T,1}, ::Type{Vec{N,T}}) where {N,T}
+            @assert length(xs) % N == 0
+            sv = Vec{N,T}(0)
+            @inbounds for i in 1:N:length(xs)
+                xv = vload(Vec{N,T}, xs, i)
+                sv += xv
+            end
+            sum(sv)
+        end
+
+        let xs = valloc(Float64, L4, 4*L4) do i i end
+            s = vsum(xs, V4F64)
+            @test s === (x->(x^2+x)/2)(Float64(4*L4))
+            # @code_native vsum(xs, V4F64)
+        end
+
+        function vadd_masked!(xs::AbstractArray{T,1}, ys::AbstractArray{T,1},
+                              ::Type{Vec{N,T}}) where {N, T}
+            @assert length(ys) == length(xs)
+            limit = length(xs) - (N-1)
+            vlimit = Vec{N,Int}(let l=length(xs); (l:l+N-1...,) end)
+            @inbounds for i in 1:N:length(xs)
+                xv = vload(Vec{N,T}, xs, i)
+                yv = vload(Vec{N,T}, ys, i)
+                xv += yv
+                if i <= limit
+                    vstore(xv, xs, i)
+                else
+                    mask = Vec{N,Int}(i) <= vlimit
+                    vstore(xv, xs, i, mask)
+                end
+            end
+        end
+
+        let xs = valloc(Float64, 4, 13) do i i end,
+            ys = valloc(Float64, 4, 13) do i 1 end
+            vadd_masked!(xs, ys, V4F64)
+            @test xs == Float64[i+1 for i in 1:13]
+            # @code_native vadd!(xs, ys, V4F64)
+        end
+
+        function vsum_masked(xs::AbstractArray{T,1}, ::Type{Vec{N,T}}) where {N,T}
+            vlimit = Vec{N,Int}(let l=length(xs); (l:l+N-1...,) end)
+            sv = Vec{N,T}(0)
+            @inbounds for i in 1:N:length(xs)
+                mask = Vec{N,Int}(i) <= vlimit
+                xv = vload(Vec{N,T}, xs, i, mask)
+                sv += xv
+            end
+            sum(sv)
+        end
+
+        let xs = valloc(Float64, 4, 13) do i i end
+            s = vsum_masked(xs, V4F64)
+            @code_llvm vsum(xs, V4F64)
+            @code_native vsum(xs, V4F64)
+            @test s === sum(xs)
+        end
+    end
+
+    @testset "Vector shuffles" begin
+
+        for T in (Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Float32,Float64)
+            a = Vec{4,T}((1,2,3,4))
+            b = Vec{4,T}((5,6,7,8))
+            @test shufflevector(a, b, Val{(2,3,4,5)}) === Vec{4,T}((3,4,5,6))
+            @test shufflevector(a, b, Val{(1,7,5,5)}) === Vec{4,T}((2,8,6,6))
+            @test shufflevector(a, b, Val{0:3}) === a
+            @test shufflevector(a, b, Val{4:7}) === b
+            @test shufflevector(a, Val{(1,0,2,3)}) === Vec{4,T}((2,1,3,4))
+            @test shufflevector(a, b, Val{(0,1,4,5,2,3,6,7)}) === Vec{8,T}((1,2,5,6,3,4,7,8))
+            @test shufflevector(shufflevector(a, b, Val{(6,:undef,0,:undef)}), Val{(0,2)}) === Vec{2,T}((7,1))
+            @test isa(shufflevector(a, Val{(:undef,:undef,:undef,:undef)}), Vec{4,T})
+            c = Vec{8,T}((1:8...,))
+            d = Vec{8,T}((9:16...,))
+            @test shufflevector(c, d, Val{(0,1,8,15)}) === Vec{4,T}((1,2,9,16))
+            @test shufflevector(c, d, Val{1:2:15}) === Vec{8,T}((2:2:16...,))
+        end
+
+        let
+            a = Vec{4,Bool}((true,false,true,false))
+            b = Vec{4,Bool}((false,false,true,true))
+            @test shufflevector(a, b, Val{(2,3,4,5)}) === Vec{4,Bool}((true,false,false,false))
+        end
+    end
 end


### PR DESCRIPTION
This PR
- deprecated any use of `Compat`
- stopped using `@info`
- Refactored into using the `@testset` macro
- had to use `global` for the local scoped `const` declarations so they could be accessed across testsets.

@vchuravy 