### PR TITLE
remove DenseVector subtyping

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ By exposing SIMD vector types and corresponding operations, the programmer can e
 Here is a simple example for a manually vectorized code that adds two arrays:
 ```Julia
 using SIMD
-function vadd!{N,T}(xs::Vector{T}, ys::Vector{T}, ::Type{Vec{N,T}})
+function vadd!(xs::Vector{T}, ys::Vector{T}, ::Type{Vec{N,T}}) where {N, T}
     @assert length(ys) == length(xs)
     @assert length(xs) % N == 0
     @inbounds for i in 1:N:length(xs)
@@ -79,7 +79,7 @@ sum(v)
 When using explicit SIMD vectorization, it is convenient to allocate arrays still as arrays of scalars, not as arrays of vectors. The `vload` and `vstore` functions allow reading vectors from and writing vectors into arrays, accessing several contiguous array elements.
 
 ```Julia
-arr = Vector{Float64}(100)
+arr = Vector{Float64}(undef, 100)
 ...
 xs = vload(Vec{4,Float64}, arr, i)
 ...
@@ -97,7 +97,7 @@ a = Vec{4, Int32}((1,2,3,4))
 b = Vec{4, Int32}((5,6,7,8))
 mask = (2,3,4,5)
 shufflevector(a, b, Val{mask})
-Int32⟨3,4,5,6⟩
+<4 x Int32>[3, 4, 5, 6]
 ```
 The mask specifies vector elements counted across `a` and `b`,
 starting at 0 to follow the LLVM convention. If you don't care about
@@ -112,7 +112,7 @@ There is also a one operand version of the function:
 a = Vec{4, Int32}((1,2,3,4))
 mask = (0,3,1,2)
 shufflevector(a, Val{mask})
-Int32⟨1,4,2,3⟩
+<4 x Int32>[1, 4, 2, 3]
 ```
 
 ## Representing SIMD vector types in Julia
@@ -152,7 +152,7 @@ code would break as a result.
 
 We thus define our own SIMD vector type `Vec{N,T}`:
 ```Julia
-immutable Vec{N,T} <: DenseArray{N,1}
-    elts::NTuple{N,T}
+struct Vec{N,T}
+    elts::NTuple{N,VecElement{T}}
 end
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,17 +32,17 @@ using Test, InteractiveUtils
         global const v8i32 = ntuple(i->Int32(ifelse(isodd(i), i, -i)), L8)
         global const v4f64 = ntuple(i->Float64(ifelse(isodd(i), i, -i)), L4)
 
-        @test string(V8I32(v8i32)) == "Int32⟨" * string(v8i32)[2:end-1] * "⟩"
-        @test string(V4F64(v4f64)) == "Float64⟨" * string(v4f64)[2:end-1] * "⟩"
+        @test string(V8I32(v8i32)) == "<8 x Int32>[" * string(v8i32)[2:end-1] * "]"
+        @test string(V4F64(v4f64)) == "<4 x Float64>[" * string(v4f64)[2:end-1] * "]"
 
         @test convert(V8I32, V8I32(v8i32)) === V8I32(v8i32)
         @test convert(Vec{L8,Int64}, V8I32(v8i32)) ===
             Vec{L8, Int64}(convert(NTuple{L8,Int64}, v8i32))
 
-        @test NTuple{L8,Int32}(V8I32(v8i32)) === v8i32
-        @test NTuple{L4,Float64}(V4F64(v4f64)) === v4f64
-        @test Tuple(V8I32(v8i32)) === v8i32
-        @test Tuple(V4F64(v4f64)) === v4f64
+        @test NTuple{L8,Int32}(V8I32(v8i32)) === Tuple(v8i32)
+        @test NTuple{L4,Float64}(V4F64(v4f64)) === Tuple(v4f64)
+        @test Tuple(V8I32(v8i32)) === Tuple(v8i32)
+        @test Tuple(V4F64(v4f64)) === Tuple(v4f64)
     end
 
     @testset "Element-wise access" begin


### PR DESCRIPTION
Fixes #35 

As an indication that this is the right choice, this PR found a slow fallback in converting a `Vec` to another element type.

With this PR

```jl
julia> a = Vec{4, Float64}((1.0,2.0,3.0,4.0))
<4 x Float64>[1.0, 2.0, 3.0, 4.0]

julia> f(a) = convert(Vec{4, Float32}, a)
f (generic function with 1 method)

julia> @code_native f(a)
        vcvtpd2psy      (%rsi), %xmm0
        vmovapd %xmm0, (%rdi)
        movq    %rdi, %rax
        retq
        nopl    (%rax)
;}
```

but previously it was fell back to just iterating to create the Tuple:

```jl
julia> @code_native f(a)
        .section        __TEXT,__text,regular,pure_instructions
; Function f {
; Location: REPL[3]:1
        pushq   %r14
        pushq   %rbx
        subq    $40, %rsp
        movq    %rdi, %r14
        vxorps  %xmm0, %xmm0, %xmm0
        vmovaps %xmm0, 16(%rsp)
        movq    $0, 32(%rsp)
        movabsq $jl_get_ptls_states_fast, %rax
        callq   *%rax
        movq    %rax, %rbx
       ... 50 lines of garbage and calls etc
```

I also tweaked the printing a bit...

```jl
julia> a = Vec{4, Float64}((1.0,2.0,3.0,4.0))
<4 x Float64>[1.0, 2.0, 3.0, 4.0]
```

can remove that if it is desirable but I kinda like how it only takes 1 line and is a bit similar to LLVM.