### PR TITLE
Add gather

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ vstore(xs, arr, i)
 ```
 The `vload` call reads a vector of size 4 from the array, i.e. it reads `arr[i:i+3]`. Similarly, the `vstore` call writes the vector `xs` to the four array elements `arr[i:i+3]`.
 
+When the values to be read are stored in non-contiguous locations, the `vgather` function can be used to load them into a vector (so-called gather operation).
+
+```Julia
+idx = Vec((1, 5, 6, 9))
+vgather(arr, idx)
+```
+
 ## Vector shuffles
 
 Vector shuffle is available through the `shufflevector` function.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The SIMD package provides the usual arithmetic and logical operations for SIMD v
 
 (Currently missing: `count_ones count_zeros exponent ldexp leading_ones leading_zeros significand trailing_ones trailing_zeros`, many trigonometric functions)
 
-(Also currently missing: Type conversions, reinterpretation that changes the vector size, scatter/gather operations, masked load/store operations)
+(Also currently missing: Type conversions, reinterpretation that changes the vector size)
 
 These operators and functions are always applied element-wise, i.e. they are applied to each element in parallel, yielding again a SIMD vector as result. This means that e.g. multiplying two vectors yields a vector, and comparing two vectors yields a vector of booleans. This behaviour might seem strange and slightly unusual, but corresponds to the machine instructions provided by the hardware. It is also what is usually needed to vectorize loops.
 
@@ -92,6 +92,15 @@ When the values to be read are stored in non-contiguous locations, the `vgather`
 ```Julia
 idx = Vec((1, 5, 6, 9))
 vgather(arr, idx)
+```
+
+Likewise, storing to non-contiguous locations (scatter) can be done by the `vscatter` function.
+
+```Julia
+arr = zeros(10)
+v = Vec((1.0, 2.0, 3.0, 4.0))
+idx = Vec((1, 3, 4, 7))
+vscatter(v, arr, idx)
 ```
 
 ## Vector shuffles

--- a/src/SIMD.jl
+++ b/src/SIMD.jl
@@ -56,8 +56,9 @@ const BoolTypes = Union{Bool}
 const IntTypes = Union{Int8, Int16, Int32, Int64, Int128}
 const UIntTypes = Union{UInt8, UInt16, UInt32, UInt64, UInt128}
 const IntegerTypes = Union{BoolTypes, IntTypes, UIntTypes}
+const IndexTypes = Union{IntegerTypes, Ptr}
 const FloatingTypes = Union{Float16, Float32, Float64}
-const ScalarTypes = Union{IntegerTypes, FloatingTypes}
+const ScalarTypes = Union{IndexTypes, FloatingTypes}
 
 const VE = Base.VecElement
 
@@ -195,6 +196,7 @@ llvmtype(::Type{Int16}) = "i16"
 llvmtype(::Type{Int32}) = "i32"
 llvmtype(::Type{Int64}) = "i64"
 llvmtype(::Type{Int128}) = "i128"
+llvmtype(::Type{<:Ptr}) = llvmtype(Int)
 
 llvmtype(::Type{UInt8}) = "i8"
 llvmtype(::Type{UInt16}) = "i16"
@@ -247,8 +249,8 @@ function llvmtypedconst(::Type{Bool}, val)
 end
 
 # Type-dependent LLVM intrinsics
-llvmins(::Type{Val{:+}}, N, ::Type{T}) where {T <: IntegerTypes} = "add"
-llvmins(::Type{Val{:-}}, N, ::Type{T}) where {T <: IntegerTypes} = "sub"
+llvmins(::Type{Val{:+}}, N, ::Type{T}) where {T <: IndexTypes} = "add"
+llvmins(::Type{Val{:-}}, N, ::Type{T}) where {T <: IndexTypes} = "sub"
 llvmins(::Type{Val{:*}}, N, ::Type{T}) where {T <: IntegerTypes} = "mul"
 llvmins(::Type{Val{:div}}, N, ::Type{T}) where {T <: IntTypes} = "sdiv"
 llvmins(::Type{Val{:rem}}, N, ::Type{T}) where {T <: IntTypes} = "srem"
@@ -1088,6 +1090,22 @@ for op in (:fma, :muladd)
     end
 end
 
+# Poitner arithmetics between Ptr, IntegerTypes, and vectors of them.
+
+for op in (:+, :-)
+    @eval begin
+        @inline Base.$op(v1::Vec{N,<:Ptr}, v2::Vec{N,<:IntegerTypes}) where {N} =
+            llvmwrap(Val{$(QuoteNode(op))}, v1, v2)
+        @inline Base.$op(v1::Vec{N,<:IntegerTypes}, v2::Vec{N,<:Ptr}) where {N} =
+            llvmwrap(Val{$(QuoteNode(op))}, v1, v2)
+        @inline Base.$op(s1::P, v2::Vec{N,<:IntegerTypes}) where {N,P<:Ptr} =
+            $op(Vec{N,P}(s1), v2)
+        @inline Base.$op(v1::Vec{N,<:IntegerTypes}, s2::P) where {N,P<:Ptr} =
+            $op(v1, Vec{N,P}(s2))
+    end
+end
+
+
 # Reduction operations
 
 # TODO: map, mapreduce
@@ -1420,6 +1438,64 @@ end
                          i::Integer, mask::Vec{N,Bool}) where {N,T}
     vstore(v, arr, i, mask, Val{true})
 end
+
+export vgather, vgathera
+
+@generated function vgather(
+        ::Type{Vec{N,T}}, ptrs::Vec{N,Ptr{T}}, mask::Vec{N,Bool},
+        ::Type{Val{Aligned}} = Val{false}) where {N,T,Aligned}
+    @assert isa(Aligned, Bool)
+    ptyp = llvmtype(Int)
+    typ = llvmtype(T)
+    vptyp = "<$N x $typ*>"
+    vtyp = "<$N x $typ>"
+    btyp = llvmtype(Bool)
+    vbtyp = "<$N x $btyp>"
+    decls = []
+    instrs = []
+    if Aligned
+        align = N * sizeof(T)
+    else
+        align = sizeof(T)   # This is overly optimistic
+    end
+
+    if VERSION < v"v0.7.0-DEV"
+        push!(instrs, "%ptrs = bitcast <$N x $typ*> %0 to $vptyp")
+    else
+        push!(instrs, "%ptrs = inttoptr <$N x $ptyp> %0 to $vptyp")
+    end
+    push!(instrs, "%mask = trunc $vbtyp %1 to <$N x i1>")
+    push!(decls,
+        "declare $vtyp @llvm.masked.gather.$(suffix(N,T))($vptyp, i32, " *
+            "<$N x i1>, $vtyp)")
+    push!(instrs,
+        "%res = call $vtyp @llvm.masked.gather.$(suffix(N,T))($vptyp %ptrs, " *
+            "i32 $align, <$N x i1> %mask, $vtyp $(llvmconst(N, T, 0)))")
+    push!(instrs, "ret $vtyp %res")
+    quote
+        $(Expr(:meta, :inline))
+        Vec{N,T}(Base.llvmcall($((join(decls, "\n"), join(instrs, "\n"))),
+            NTuple{N,VE{T}}, Tuple{NTuple{N,VE{Ptr{T}}}, NTuple{N,VE{Bool}}},
+            ptrs.elts, mask.elts))
+    end
+end
+
+@inline vgathera(::Type{Vec{N,T}}, ptrs::Vec{N,Ptr{T}},
+                 mask::Vec{N,Bool}) where {N,T} =
+    vgather(Vec{N,T}, ptrs, mask, Val{true})
+
+@inline vgather(arr::Union{Array{T,1},SubArray{T,1}},
+                idx::Vec{N,<:Integer},
+                mask::Vec{N,Bool} = Vec(ntuple(_ -> true, N)),
+                ::Type{Val{Aligned}} = Val{false}) where {N,T,Aligned} =
+    vgather(Vec{N,T},
+            pointer(arr) + sizeof(T) * (idx - 1),
+            mask, Val{Aligned})
+
+@inline vgathera(arr::Union{Array{T,1},SubArray{T,1}},
+                 idx::Vec{N,<:Integer},
+                 mask::Vec{N,Bool} = Vec(ntuple(_ -> true, N))) where {N,T} =
+    vgather(arr, idx, mask, Val{true})
 
 # Vector shuffles
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -303,17 +303,23 @@ using Test, InteractiveUtils
     end
 
     @testset "Gather function" begin
-        arri32 .= 1:length(arri32)
-        idx = Vec(Tuple(floor.(
-            Int, range(1, stop=length(arri32), length=length(V8I32)))))
-        @test vgather(arri32, idx) === convert(V8I32, idx)
-        @test vgathera(arri32, idx) === convert(V8I32, idx)
+        for (arr, VT) in [(arri32, V8I32), (arrf64, V4F64)]
+            arr .= 1:length(arr)
+            idxarr = floor.(Int, range(1, stop=length(arr), length=length(VT)))
 
-        arrf64 .= 1:length(arrf64)
-        idx = Vec(Tuple(floor.(
-            Int, range(1, stop=length(arrf64), length=length(V4F64)))))
-        @test vgather(arrf64, idx) === convert(V4F64, idx)
-        @test vgathera(arrf64, idx) === convert(V4F64, idx)
+            idx = Vec(Tuple(idxarr))
+            @test vgather(arr, idx) === convert(VT, idx)
+            @test vgathera(arr, idx) === convert(VT, idx)
+
+            # Masked gather
+            maskarr = zeros(Bool, length(VT))
+            for i in 1:length(VT)
+                maskarr[i] = true
+                mask = Vec(Tuple(maskarr))
+                @test vgather(arr, idx, mask) === VT(Tuple(idxarr .* maskarr))
+                @test vgathera(arr, idx, mask) === VT(Tuple(idxarr .* maskarr))
+            end
+        end
     end
 
     @testset "Real-world examples" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -302,7 +302,7 @@ using Test, InteractiveUtils
         end
     end
 
-    @testset "Gather function" begin
+    @testset "Gather and scatter function" begin
         for (arr, VT) in [(arri32, V8I32), (arrf64, V4F64)]
             arr .= 1:length(arr)
             idxarr = floor.(Int, range(1, stop=length(arr), length=length(VT)))
@@ -318,6 +318,26 @@ using Test, InteractiveUtils
                 mask = Vec(Tuple(maskarr))
                 @test vgather(arr, idx, mask) === VT(Tuple(idxarr .* maskarr))
                 @test vgathera(arr, idx, mask) === VT(Tuple(idxarr .* maskarr))
+            end
+
+            # Scatter
+            varr = convert.(eltype(VT), idxarr .* 123)
+            v = Vec(Tuple(varr))
+
+            vscatter(v, fill!(arr, 0), idx)
+            @test arr[idxarr] == varr
+            vscattera(v, fill!(arr, 0), idx)
+            @test arr[idxarr] == varr
+
+            # Masked scatter
+            maskarr = zeros(Bool, length(VT))
+            for i in 1:length(VT)
+                maskarr[i] = true
+                mask = Vec(Tuple(maskarr))
+                vscatter(v, fill!(arr, 0), idx, mask)
+                @test arr[idxarr] == varr .* maskarr
+                vscattera(v, fill!(arr, 0), idx, mask)
+                @test arr[idxarr] == varr .* maskarr
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -302,6 +302,20 @@ using Test, InteractiveUtils
         end
     end
 
+    @testset "Gather function" begin
+        arri32 .= 1:length(arri32)
+        idx = Vec(Tuple(floor.(
+            Int, range(1, stop=length(arri32), length=length(V8I32)))))
+        @test vgather(arri32, idx) === convert(V8I32, idx)
+        @test vgathera(arri32, idx) === convert(V8I32, idx)
+
+        arrf64 .= 1:length(arrf64)
+        idx = Vec(Tuple(floor.(
+            Int, range(1, stop=length(arrf64), length=length(V4F64)))))
+        @test vgather(arrf64, idx) === convert(V4F64, idx)
+        @test vgathera(arrf64, idx) === convert(V4F64, idx)
+    end
+
     @testset "Real-world examples" begin
 
         function vadd!(xs::AbstractArray{T,1}, ys::AbstractArray{T,1},


### PR DESCRIPTION
Hi, thanks for implementing this library!

I wanted to play with the gather operation so I implemented it using SIMD.jl infrastructure (whish was surprisingly straightforward).  Do you think it's good to add this?

As a side note, if you want to get fancy, I think indexing `arr[idx]` by a `Vec` can be a sugar for `vgather` (and `arr[idx] = vec` for scatter in the future).