### PR TITLE
propagate inbounds for getindex

### DIFF
--- a/src/SIMD.jl
+++ b/src/SIMD.jl
@@ -449,8 +449,8 @@ end
 end
 setindex(v::Vec{N,T}, x::Number, i) where {N,T} = setindex(v, Int(i), x)
 
-Base.getindex(v::Vec{N,T}, ::Type{Val{I}}) where {N,T,I} = v.elts[I].value
-Base.getindex(v::Vec{N,T}, i) where {N,T} = v.elts[i].value
+Base.@propagate_inbounds Base.getindex(v::Vec{N,T}, ::Type{Val{I}}) where {N,T,I} = v.elts[I].value
+Base.@propagate_inbounds Base.getindex(v::Vec{N,T}, i) where {N,T} = v.elts[i].value
 
 # Type conversion
 


### PR DESCRIPTION

Using:

```jl
julia> f(v, i) = @inbounds v[i]

julia> @code_llvm f(Vec((1.0,2.0,3.0,4.0)), 1);
```

Before:

```
  %2 = add i64 %1, -1
  %3 = icmp ult i64 %2, 4
  br i1 %3, label %pass, label %fail

fail:                                             ; preds = %top
  %4 = bitcast { <4 x double> } addrspace(11)* %0 to i8 addrspace(11)*
  call void @jl_bounds_error_unboxed_int(i8 addrspace(11)* %4, %jl_value_t* inttoptr (i64 4607209856 to %jl_value_t*), i64 %1)
  unreachable

pass:                                             ; preds = %top
  %5 = getelementptr inbounds { <4 x double> }, { <4 x double> } addrspace(11)* %0, i64 0, i32 0, i64 %2
;}}
  %6 = load double, double addrspace(11)* %5, align 8
  ret double %6
}
```

:(

After:

```
  %2 = add i64 %1, -1
  %3 = getelementptr inbounds { <4 x double> }, { <4 x double> } addrspace(11)* %0, i64 0, i32 0, i64 %2
  %4 = load double, double addrspace(11)* %3, align 8
  ret double %4
}
```

:)


