### PR TITLE
Implement literal_pow for Vec

### DIFF
--- a/src/SIMD.jl
+++ b/src/SIMD.jl
@@ -991,6 +991,12 @@ end
 @inline Base.flipsign(v1::Vec{N,T}, v2::Vec{N,T}) where {N,T<:FloatingTypes} =
     vifelse(signbit(v2), -v1, v1)
 
+# Do what Base does for HWNumber:
+@inline Base.literal_pow(::typeof(^), x::Vec, ::Val{0}) = one(typeof(x))
+@inline Base.literal_pow(::typeof(^), x::Vec, ::Val{1}) = x
+@inline Base.literal_pow(::typeof(^), x::Vec, ::Val{2}) = x*x
+@inline Base.literal_pow(::typeof(^), x::Vec, ::Val{3}) = x*x*x
+
 for op in (:fma, :muladd)
     @eval begin
         @inline function Base.$op(v1::Vec{N,T},

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -113,6 +113,11 @@ using Test, InteractiveUtils
             @test Tuple(op(V8I32(v8i32), -3)) === map(x->op(x,-3), v8i32)
             @test Tuple(op(V8I32(v8i32), V8I32(v8i32))) === map(op, v8i32, v8i32)
         end
+
+        @test Tuple(V8I32(v8i32)^0) === v8i32.^0
+        @test Tuple(V8I32(v8i32)^1) === v8i32.^1
+        @test Tuple(V8I32(v8i32)^2) === v8i32.^2
+        @test Tuple(V8I32(v8i32)^3) === v8i32.^3
     end
 
     @testset "Floating point arithmetic functions" begin
@@ -197,6 +202,11 @@ using Test, InteractiveUtils
                 copysign, flipsign, max, min, rem)
             @test Tuple(op(V4F64(v4f64), V4F64(v4f64b))) === map(op, v4f64, v4f64b)
         end
+
+        @test Tuple(V4F64(v4f64)^0) === v4f64.^0
+        @test Tuple(V4F64(v4f64)^1) === v4f64.^1
+        @test Tuple(V4F64(v4f64)^2) === v4f64.^2
+        @test Tuple(V4F64(v4f64)^3) === v4f64.^3
 
         for op in (fma, vifelsebool, muladd)
             @test Tuple(op(V4F64(v4f64), V4F64(v4f64b), V4F64(v4f64c))) ===


### PR DESCRIPTION
This PR implements `literal_pow` for `Vec` so that, e.g., `v^2` is evaluated as `v*v`.  This is implemented for `v^n` where `n = 0, 1, 2, 3` as done in `Base`.

Before this PR (SIMD.jl v2.2.0), following benchmark shows that vectorized sum of `x -> x^3 + x^2 + x^1 + x^0` was ~300x _slower_ than `Base.sum`.  With this PR, it's slightly faster (~3%).

```julia
using SIMD

@inline function vsum(f, xs, ::Val{N} = Val(16)) where N
    @assert length(xs) % N == 0
    T = eltype(xs)
    vacc = zero(Vec{N, T})
    @inbounds for i in 1:N:length(xs)
        vacc += f(vload(Vec{N,T}, xs, i))
    end
    return sum(vacc)
end

using BenchmarkTools
xs = randn(2^10)
f(x) = x^3 + x^2 + x^1 + x^0
@assert vsum(f, xs) ≈ sum(f, xs)
(bv = @benchmark vsum(f, $xs)) |> display
(bs = @benchmark sum(f, $xs)) |> display
@show minimum(bv).time / minimum(bs).time
```
