### PR TITLE
Fix Project.toml UUID

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "SIMD"
-uuid = "41203a48-d602-4ede-a34e-234653443e97"
+uuid = "fdea26ae-647d-5447-a871-4b548cad5224"
 authors = ["Erik Schnetter <schnetter@gmail.com>"]
 version = "2.0.1"
 


### PR DESCRIPTION
It looks like the UUID in Project.toml is different from the one in the registry: https://github.com/JuliaRegistries/General/blob/master/S/SIMD/Package.toml

This PR make `]test SIMD` works after `]dev SIMD`, although I remember it worked before... Maybe something changed in Pkg.jl?  Anyway, I think it's better to match the UUID.