### PR TITLE
Remove spurious dependency on InteractiveUtils

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,9 +6,6 @@ version = "2.8.0"
 [compat]
 julia = "1"
 
-[deps]
-InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-
 [extras]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
While InteractiveUtils is used for testing, it is not used within the package itself.