### PR TITLE
Add expandload and compressstore

### DIFF
--- a/src/LLVM_intrinsics.jl
+++ b/src/LLVM_intrinsics.jl
@@ -461,7 +461,7 @@ end
     decl = "declare <$N x $(d[T])> @llvm.masked.expandload.$(suffix(N, T))(<$N x $(d[T])>*, <$N x i1>, <$N x $(d[T])>)"
     s = """
     %mask = trunc <$(N) x i8> %1 to <$(N) x i1>
-    %ptr = inttoptr $(d[Int]) %1 to <$N x $(d[T])>*
+    %ptr = inttoptr $(d[Int]) %0 to <$N x $(d[T])>*
     %res = call <$N x $(d[T])> @llvm.masked.expandload.$(suffix(N, T))(<$N x $(d[T])>* %ptr, <$N x i1> %mask, <$N x $(d[T])> zeroinitializer)
     ret <$N x $(d[T])> %res
     """

--- a/src/LLVM_intrinsics.jl
+++ b/src/LLVM_intrinsics.jl
@@ -458,11 +458,11 @@ end
 
 @generated function maskedexpandload(ptr::Ptr{T}, mask::LVec{N,Bool}) where {N, T}
     # TODO: Allow setting the passthru
-    decl = "declare <$N x $(d[T])> @llvm.masked.expandload.$(suffix(N, T))(<$N x $(d[T])>*, <$N x i1>, <$N x $(d[T])>)"
+    decl = "declare <$N x $(d[T])> @llvm.masked.expandload.$(suffix(N, T))($(d[T])*, <$N x i1>, <$N x $(d[T])>)"
     s = """
     %mask = trunc <$(N) x i8> %1 to <$(N) x i1>
-    %ptr = inttoptr $(d[Int]) %0 to <$N x $(d[T])>*
-    %res = call <$N x $(d[T])> @llvm.masked.expandload.$(suffix(N, T))(<$N x $(d[T])>* %ptr, <$N x i1> %mask, <$N x $(d[T])> zeroinitializer)
+    %ptr = inttoptr $(d[Int]) %0 to $(d[T])*
+    %res = call <$N x $(d[T])> @llvm.masked.expandload.$(suffix(N, T))($(d[T])* %ptr, <$N x i1> %mask, <$N x $(d[T])> zeroinitializer)
     ret <$N x $(d[T])> %res
     """
     return :(
@@ -473,11 +473,11 @@ end
 
 @generated function maskedcompressstore(x::LVec{N, T}, ptr::Ptr{T},
                                         mask::LVec{N,Bool}) where {N, T}
-    decl = "declare <$N x $(d[T])> @llvm.masked.compressstore.$(suffix(N, T))(<$N x $(d[T])>, <$N x $(d[T])>*, <$N x i1>)"
+    decl = "declare <$N x $(d[T])> @llvm.masked.compressstore.$(suffix(N, T))(<$N x $(d[T])>, $(d[T])*, <$N x i1>)"
     s = """
     %mask = trunc <$(N) x i8> %2 to <$(N) x i1>
-    %ptr = inttoptr $(d[Int]) %1 to <$N x $(d[T])>*
-    call <$N x $(d[T])> @llvm.masked.compressstore.$(suffix(N, T))(<$N x $(d[T])> %0, <$N x $(d[T])>* %ptr, <$N x i1> %mask)
+    %ptr = inttoptr $(d[Int]) %1 to $(d[T])*
+    call <$N x $(d[T])> @llvm.masked.compressstore.$(suffix(N, T))(<$N x $(d[T])> %0, $(d[T])* %ptr, <$N x i1> %mask)
     ret void
     """
     return :(

--- a/src/LLVM_intrinsics.jl
+++ b/src/LLVM_intrinsics.jl
@@ -732,17 +732,18 @@ end
 
 # See: https://llvm.org/docs/LangRef.html#id839
 @generated function reduce_add(x::LVec{N, Bool}) where {N}
-    if N < 64
+    native_bit_width = sizeof(Int) * 8
+    if N < native_bit_width
         ret = """
-        %res = zext i$(N) %maskipopcnt to i64
-        ret i64 %res
+        %res = zext i$(N) %maskipopcnt to i$(native_bit_width)
+        ret i$(native_bit_width) %res
         """
-    elseif N == 64
-        ret = "ret i64 %maskipopcnt"
+    elseif N == native_bit_width
+        ret = "ret i$(native_bit_width) %maskipopcnt"
     else
         ret = """
-        %res = trunc i$(N) %maskipopcnt to i64
-        ret i64 %res
+        %res = trunc i$(N) %maskipopcnt to i$(native_bit_width)
+        ret i$(native_bit_width) %res
         """
     end
     decl = "declare i$(N) @llvm.ctpop.i$(N)(i$(N))"
@@ -754,7 +755,7 @@ end
     """
     return :(
         $(Expr(:meta, :inline));
-        Base.llvmcall(($decl, $s), Int64, Tuple{LVec{N, Bool}}, x)
+        Base.llvmcall(($decl, $s), Int, Tuple{LVec{N, Bool}}, x)
     )
 end
 

--- a/src/SIMD.jl
+++ b/src/SIMD.jl
@@ -2,8 +2,9 @@ module SIMD
 
 using Base: @propagate_inbounds
 
-export Vec, vload, vloada, vloadnt, vstore, vstorea, vstorent, vgather, vgathera,
-       vscatter, vscattera, shufflevector, vifelse, valloc, VecRange
+export Vec, vload, vloada, vloadnt, vloadx, vstore, vstorea, vstorent, vstorec,
+       vgather, vgathera, vscatter, vscattera, shufflevector, vifelse, valloc,
+       VecRange
 
 const VE         = Base.VecElement
 const LVec{N, T} = NTuple{N, VE{T}}

--- a/src/arrayops.jl
+++ b/src/arrayops.jl
@@ -81,6 +81,31 @@ end
 @propagate_inbounds vstorea(x::Vec, a, i, mask=nothing) = vstore(x, a, i, nothing, Val(true))
 @propagate_inbounds vstorent(x::Vec, a, i, mask=nothing) = vstore(x, a, i, nothing, Val(true), Val(true))
 
+@inline vloadx(ptr::Ptr, mask::Vec{<:Any, Bool}) =
+    Vec(Intrinsics.maskedexpandload(ptr, mask))
+
+@propagate_inbounds function vloadx(a::FastContiguousArray{T,1},
+                                    i::Integer, mask::Vec{N, Bool}) where {N, T}
+    @boundscheck checkbounds(a, i:i + N - 1)
+    return GC.@preserve a begin
+        ptr = pointer(a, i)
+        vloadx(x, ptr, mask)
+    end
+end
+
+@inline vstorec(x::Vec{N, T}, ptr::Ptr{T}, mask::Vec{N, Bool}) where {N, T} =
+    Intrinsics.maskedcompressstore(x.data, ptr, mask.data)
+
+@propagate_inbounds function vstorec(x::Vec{N, T}, a::FastContiguousArray{T,1},
+                                     i::Integer, mask::Vec{N, Bool}) where {N, T}
+    @boundscheck checkbounds(a, i:i + N - 1)
+    GC.@preserve a begin
+        ptr = pointer(a, i)
+        vstorec(x, ptr, mask)
+    end
+    return a
+end
+
 function valloc(::Type{T}, N::Int, sz::Int) where T
     @assert N > 0
     @assert sz >= 0

--- a/src/arrayops.jl
+++ b/src/arrayops.jl
@@ -82,14 +82,14 @@ end
 @propagate_inbounds vstorent(x::Vec, a, i, mask=nothing) = vstore(x, a, i, nothing, Val(true), Val(true))
 
 @inline vloadx(ptr::Ptr, mask::Vec{<:Any, Bool}) =
-    Vec(Intrinsics.maskedexpandload(ptr, mask))
+    Vec(Intrinsics.maskedexpandload(ptr, mask.data))
 
 @propagate_inbounds function vloadx(a::FastContiguousArray{T,1},
                                     i::Integer, mask::Vec{N, Bool}) where {N, T}
     @boundscheck checkbounds(a, i:i + N - 1)
     return GC.@preserve a begin
         ptr = pointer(a, i)
-        vloadx(x, ptr, mask)
+        vloadx(ptr, mask)
     end
 end
 

--- a/src/simdvec.jl
+++ b/src/simdvec.jl
@@ -448,7 +448,7 @@ const HORZ_REDUCTION_OPS = [
     (min , IntTypes      , Intrinsics.reduce_smin)
     (min , UIntTypes     , Intrinsics.reduce_umin)
     (min , FloatingTypes , Intrinsics.reduce_fmin)
-    (+   , IntegerTypes  , Intrinsics.reduce_add)
+    (+   , Union{IntegerTypes, Bool}  , Intrinsics.reduce_add)
     (*   , IntegerTypes  , Intrinsics.reduce_mul)
     (+   , FloatingTypes , Intrinsics.reduce_fadd)
     (*   , FloatingTypes , Intrinsics.reduce_fmul)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -449,20 +449,24 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
     end
 
     @testset "compressstore" begin
-        for arr in [arri32, arrf64]
-            VT = Vec{4,eltype(arr)}
-            arr .= 1:length(arr)
-            x = VT(Tuple(arr[1:4]))
-            @test vstorec(x, zero(arr), 1, Vec((true, false, false, true))) ==
-                [[arr[1], arr[4]]; zero(arr)[3:end]]
-            @test vstorec(x, zero(arr), 1, Vec((true, false, true, false))) ==
-                [[arr[1], arr[3]]; zero(arr)[3:end]]
-            @test vstorec(x, zero(arr), 1, Vec((true, true, false, false))) ==
-                [[arr[1], arr[2]]; zero(arr)[3:end]]
-            @test vstorec(x, zero(arr), 1, Vec((true, false, false, false))) ==
-                [[arr[1]]; zero(arr)[2:end]]
-            @test vstorec(x, zero(arr), 1, Vec((false, false, false, false))) ==
-                zero(arr)
+        if Base.libllvm_version >= v"9" || Sys.CPU_NAME == "skylake"
+            for arr in [arri32, arrf64]
+                VT = Vec{4,eltype(arr)}
+                arr .= 1:length(arr)
+                x = VT(Tuple(arr[1:4]))
+                @test vstorec(x, zero(arr), 1, Vec((true, false, false, true))) ==
+                    [[arr[1], arr[4]]; zero(arr)[3:end]]
+                @test vstorec(x, zero(arr), 1, Vec((true, false, true, false))) ==
+                    [[arr[1], arr[3]]; zero(arr)[3:end]]
+                @test vstorec(x, zero(arr), 1, Vec((true, true, false, false))) ==
+                    [[arr[1], arr[2]]; zero(arr)[3:end]]
+                @test vstorec(x, zero(arr), 1, Vec((true, false, false, false))) ==
+                    [[arr[1]]; zero(arr)[2:end]]
+                @test vstorec(x, zero(arr), 1, Vec((false, false, false, false))) ==
+                    zero(arr)
+            end
+        else
+            @info "Skipping tests for `expandload`" Base.libllvm_version Sys.CPU_NAME
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -328,6 +328,14 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
         @test sum(tf) == reduce(+, tf) == 2
         @test sum(f) == reduce(+, f) == 0
 
+        b64 = rand(Bool, 64)
+        tf64 = Vec(b64...)
+        @test sum(tf64) == sum(b64)
+
+        b65 = rand(Bool, 65)
+        tf65 = Vec(b65...)
+        @test sum(tf65) == sum(b65)
+
         for op in (maximum, minimum, sum, prod)
             @test op(V4F64(v4f64)) === op(v4f64)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -466,7 +466,7 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
                     zero(arr)
             end
         else
-            @info "Skipping tests for `expandload`" Base.libllvm_version Sys.CPU_NAME
+            @info "Skipping tests for `compressstore`" Base.libllvm_version Sys.CPU_NAME
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -742,19 +742,21 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
             return dest
         end
 
-        let n = 15
-            src = randn(n)
-            pred = Vector{Bool}(src .> 0)
-            dest = zero(src)
+        if Base.libllvm_version >= v"9" || Sys.CPU_NAME == "skylake"
+            let n = 15
+                src = randn(n)
+                pred = Vector{Bool}(src .> 0)
+                dest = zero(src)
 
-            vcompress!(dest, pred, src)
-            @test dest[1:sum(pred)] == src[src .> 0]
+                vcompress!(dest, pred, src)
+                @test dest[1:sum(pred)] == src[src .> 0]
 
-            @code_llvm vcompress!(dest, pred, src)
-            @code_native vcompress!(dest, pred, src)
+                @code_llvm vcompress!(dest, pred, src)
+                @code_native vcompress!(dest, pred, src)
 
-            ir = llvm_ir(vcompress!, (dest, pred, src))
-            @test occursin("masked.compressstore.v4f64", ir)
+                ir = llvm_ir(vcompress!, (dest, pred, src))
+                @test occursin("masked.compressstore.v4f64", ir)
+            end
         end
 
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -433,14 +433,18 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
     end
 
     @testset "expandload" begin
-        for arr in [arri32, arrf64]
-            VT = Vec{4,eltype(arr)}
-            arr .= 1:length(arr)
-            @test vloadx(arr, 1, Vec((true, false, false, true))) === VT((1, 0, 0, 2))
-            @test vloadx(arr, 1, Vec((true, false, true, false))) === VT((1, 0, 2, 0))
-            @test vloadx(arr, 1, Vec((true, true, false, false))) === VT((1, 2, 0, 0))
-            @test vloadx(arr, 1, Vec((true, false, false, false))) === VT((1, 0, 0, 0))
-            @test vloadx(arr, 1, Vec((false, false, false, false))) === VT((0, 0, 0, 0))
+        if Base.libllvm_version >= v"9" || Sys.CPU_NAME == "skylake"
+            for arr in [arri32, arrf64]
+                VT = Vec{4,eltype(arr)}
+                arr .= 1:length(arr)
+                @test vloadx(arr, 1, Vec((true, false, false, true))) === VT((1, 0, 0, 2))
+                @test vloadx(arr, 1, Vec((true, false, true, false))) === VT((1, 0, 2, 0))
+                @test vloadx(arr, 1, Vec((true, true, false, false))) === VT((1, 2, 0, 0))
+                @test vloadx(arr, 1, Vec((true, false, false, false))) === VT((1, 0, 0, 0))
+                @test vloadx(arr, 1, Vec((false, false, false, false))) === VT((0, 0, 0, 0))
+            end
+        else
+            @info "Skipping tests for `expandload`" Base.libllvm_version Sys.CPU_NAME
         end
     end
 


### PR DESCRIPTION
This PR adds Masked Vector Expanding Load and Compressing Store Intrinsics: https://llvm.org/docs/LangRef.html#masked-vector-expanding-load-and-compressing-store-intrinsics

I'm not sure how it should be called. I call them `vloadx` and `vstorec` to match(?) with existing names. But I don't mind renaming them to something else.

Example:

```julia
function compress_scalar!(dest, pred, src)
    j = firstindex(dest)
    @inbounds for i in eachindex(dest, src, pred)
        if pred[i]
            dest[j] = src[i]
            j += 1
        end
    end
    return dest
end

function compress_simd!(dest, pred, src, ::Val{N} = Val(4)) where {N}
    @assert axes(dest) == axes(src) == axes(pred)
    simd_bound = lastindex(src) - N + 1
    i = firstindex(src)
    j = firstindex(dest)
    lanes = VecRange{N}(0)
    @inbounds while i <= simd_bound
        mask = pred[lanes + i]
        vstorec(src[lanes + i], dest, j, mask)
        j += sum(mask)
        i += N
    end
    @inbounds while i <= lastindex(src)
        if pred[i]
            dest[j] = src[i]
            j += 1
        end
        i += 1
    end
    return dest
end
```

Benchmark resutls (https://github.com/tkf/MiscBenchmarks.jl/pull/2 / https://travis-ci.com/github/tkf/MiscBenchmarks.jl/jobs/314648574#L476):

```
                                            ID            time GC time memory allocations
  –––––––––––––––––––––––––––––––––––––––––––– ––––––––––––––– ––––––– –––––– –––––––––––
     ["compressstore", ":n => 1024", "scalar"] 667.303 ns (5%)                           
       ["compressstore", ":n => 1024", "simd"] 451.107 ns (5%)                           
    ["compressstore", ":n => 32768", "scalar"] 129.256 μs (5%)                           
      ["compressstore", ":n => 32768", "simd"]  12.930 μs (5%)                           
  ["compressstore", ":n => 1048576", "scalar"]   4.348 ms (5%)                           
    ["compressstore", ":n => 1048576", "simd"] 451.774 μs (5%)                           
```
