### PR TITLE
Don't pass a tuple of indices when calculating the pointer in an 1D array.

### DIFF
--- a/src/arrayops.jl
+++ b/src/arrayops.jl
@@ -274,6 +274,8 @@ Base.@propagate_inbounds _pointer(arr::Array, i, I) =
     pointer(arr, LinearIndices(arr)[i, I...])
 Base.@propagate_inbounds _pointer(arr::Base.FastContiguousSubArray, i, I) =
     pointer(arr, (i, I...))
+Base.@propagate_inbounds _pointer(arr::Base.FastContiguousSubArray, i, I::Tuple{}) =
+    pointer(arr, i)
 Base.@propagate_inbounds _pointer(arr::SubArray, i, I) =
     pointer(Base.unsafe_view(arr, 1, I...), i)
 


### PR DESCRIPTION
Fixes https://github.com/eschnett/SIMD.jl/pull/68#issuecomment-658143620