### PR TITLE
Fix gather/scatter with multi-dimensional arrays

### DIFF
--- a/src/arrayops.jl
+++ b/src/arrayops.jl
@@ -144,6 +144,8 @@ end
                  mask::Vec{N,Bool}=one(Vec{N,Bool}),
                  ::Val{Aligned}=Val(false)) where {N, T<:ScalarTypes, Aligned} =
     return Vec(Intrinsics.maskedgather(ptrs.data, mask.data))
+@inline vgather(ptrs::Vec{<:Any,<:Ptr{<:ScalarTypes}}, ::Nothing, aligned::Val = Val(false)) =
+    vgather(ptrs, one(Vec{length(ptrs),Bool}), aligned)
 @propagate_inbounds function vgather(a::FastContiguousArray{T,1}, idx::Vec{N, Int},
                                      mask::Vec{N,Bool}=one(Vec{N,Bool}),
                                      ::Val{Aligned}=Val(false)) where {N, T<:ScalarTypes, Aligned}
@@ -165,6 +167,9 @@ end
 @propagate_inbounds vscatter(x::Vec{N,T}, ptrs::Vec{N,Ptr{T}},
                              mask::Vec{N,Bool}, ::Val{Aligned}=Val(false)) where {N, T<:ScalarTypes, Aligned} =
     Intrinsics.maskedscatter(x.data, ptrs.data, mask.data)
+@inline vscatter(x::Vec{N,T}, ptrs::Vec{N,Ptr{T}},
+                 ::Nothing, aligned::Val=Val(false)) where {N, T<:ScalarTypes} =
+    vscatter(x, ptrs, one(Vec{N, Bool}), aligned)
 @propagate_inbounds function vscatter(x::Vec{N,T}, a::FastContiguousArray{T,1}, idx::Vec{N, Int},
                                       mask::Vec{N,Bool}=one(Vec{N, Bool}),
                                       ::Val{Aligned}=Val(false)) where {N, T<:ScalarTypes, Aligned}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -429,6 +429,62 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
                 arr[idx, mask] = v
                 @test arr[idxarr] == varr .* maskarr
             end
+
+            @testset "multi-dimensional array" begin
+                # Create an arbitrary matrix whose the beginning part
+                # is identical to `arr`:
+                m = 5
+                n = cld(length(arr), m)
+                mat = zeros(eltype(arr), m, n)
+                mat[1:length(arr)] .= arr
+
+                # Valid index for the first column:
+                idx1arr = [1, 3, 4, 5]
+                idx1 = Vec(Tuple(idx1arr))
+                @assert minimum(idx1arr) >= 1
+                @assert minimum(idx1arr) <= m
+                VT1 = Vec{4,eltype(VT)}
+                v1arr = [111, 222, 333, 444]
+                v1 = VT1(Tuple(v1arr))
+                @assert length(v1arr) == length(idx1arr)
+
+                @testset "no mask" begin
+                    @test mat[idx] === VT(Tuple(mat[idxarr]))
+                    @test mat[idx1, 1] === VT1(Tuple(mat[idx1arr, 1]))
+
+                    @testset "scatter" begin
+                        @testset "y[idx] = v" begin
+                            y = zero(mat)
+                            y[idx] = v
+                            @test y[idxarr] == varr
+                        end
+                        @testset "y[idx1, 1] = v" begin
+                            y = zero(mat)
+                            y[idx1, 1] = v1
+                            @test y[idx1arr, 1] == v1arr
+                        end
+                    end
+                end
+
+                @testset "mask[$i] == true (1D access)" for i in 1:length(VT)
+                    maskarr = zeros(Bool, length(VT))
+                    mask = Vec(Tuple(maskarr))
+
+                    y = zero(mat)
+                    y[idx, mask] = v
+                    @test y[idxarr] == varr .* maskarr
+                end
+
+                @testset "mask[$i] == true (2D access)" for i in 1:length(idx1arr)
+                    maskarr = zeros(Bool, length(idx1arr))
+                    mask = Vec(Tuple(maskarr))
+                    @test mat[idx1, 1, mask] === VT1(Tuple(idx1arr .* maskarr))
+
+                    y = zero(mat)
+                    y[idx1, 1, mask] = v1
+                    @test y[idx1arr, 1] == v1arr .* maskarr
+                end
+            end
         end
     end
 


### PR DESCRIPTION
Before this PR, gather and scatter didn't work with multi-dimensional arrays:

```julia
julia> x1 = ones(4);

julia> x1[Vec(1, 3)]
<2 x Float64>[1.0, 1.0]

julia> x2 = ones(2, 2);

julia> x2[Vec(1, 3)]
ERROR: MethodError: no method matching vgather(::Vec{2,Ptr{Float64}}, ::Nothing)
Closest candidates are:
  vgather(::Vec{N,Ptr{T}}) where {N, T<:Union{Float32, Float64, Int16, Int32, Int64, Int8, UInt16, UInt32, UInt64, UInt8}} at /home/takafumi/.julia/dev/SIMD/src/arrayops.jl:149
  vgather(::Vec{N,Ptr{T}}, ::Vec{N,Bool}) where {N, T<:Union{Float32, Float64, Int16, Int32, Int64, Int8, UInt16, UInt32, UInt64, UInt8}} at /home/takafumi/.julia/dev/SIMD/src/arrayops.jl:149
  vgather(::Vec{N,Ptr{T}}, ::Vec{N,Bool}, ::Val{Aligned}) where {N, T<:Union{Float32, Float64, Int16, Int32, Int64, Int8, UInt16, UInt32, UInt64, UInt8}, Aligned} at /home/takafumi/.julia/dev/SIMD/src/arrayops.jl:149
Stacktrace:
 [1] getindex(::Array{Float64,2}, ::Vec{2,Int64}) at /home/takafumi/.julia/dev/SIMD/src/arrayops.jl:306
 [2] top-level scope at REPL[20]:1

julia> x3 = ones(2, 2, 2);

julia> x3[Vec(1, 3)]
ERROR: MethodError: no method matching vgather(::Vec{2,Ptr{Float64}}, ::Nothing)
Closest candidates are:
  vgather(::Vec{N,Ptr{T}}) where {N, T<:Union{Float32, Float64, Int16, Int32, Int64, Int8, UInt16, UInt32, UInt64, UInt8}} at /home/takafumi/.julia/dev/SIMD/src/arrayops.jl:149
  vgather(::Vec{N,Ptr{T}}, ::Vec{N,Bool}) where {N, T<:Union{Float32, Float64, Int16, Int32, Int64, Int8, UInt16, UInt32, UInt64, UInt8}} at /home/takafumi/.julia/dev/SIMD/src/arrayops.jl:149
  vgather(::Vec{N,Ptr{T}}, ::Vec{N,Bool}, ::Val{Aligned}) where {N, T<:Union{Float32, Float64, Int16, Int32, Int64, Int8, UInt16, UInt32, UInt64, UInt8}, Aligned} at /home/takafumi/.julia/dev/SIMD/src/arrayops.jl:149
Stacktrace:
 [1] getindex(::Array{Float64,3}, ::Vec{2,Int64}) at /home/takafumi/.julia/dev/SIMD/src/arrayops.jl:306
 [2] top-level scope at REPL[22]:1

(@v1.6) pkg> st SIMD
Status `~/.julia/environments/v1.6/Project.toml`
  [fdea26ae] SIMD v3.1.0
```

This patch fixes it.
