### PR TITLE
Re-defining vloada and vstorea for pointers

### DIFF
--- a/src/arrayops.jl
+++ b/src/arrayops.jl
@@ -58,6 +58,7 @@ end
     end
 end
 @propagate_inbounds vloada(::Type{Vec{N, T}}, ptr::Ptr{T}, mask=nothing) where {N, T} = vload(Vec{N, T}, ptr, mask, Val(true))
+@propagate_inbounds vloadnt(::Type{Vec{N, T}}, ptr::Ptr{T}, mask=nothing) where {N, T} = vload(Vec{N, T}, a, i, mask, Val(true), Val(true))
 @propagate_inbounds vloada(::Type{Vec{N, T}}, a::FastContiguousArray{T,1}, i::Integer, mask=nothing) where {N, T} = vload(Vec{N, T}, a, i, mask, Val(true))
 @propagate_inbounds vloadnt(::Type{Vec{N, T}}, a::FastContiguousArray{T,1}, i::Integer, mask=nothing) where {N, T} = vload(Vec{N, T}, a, i, mask, Val(true), Val(true))
 
@@ -79,9 +80,10 @@ end
     end
     return a
 end
-@propagate_inbounds vstorea(x::Vec, ptr::Ptr, mask=nothing) = vstore(x, ptr, nothing, Val(true))
-@propagate_inbounds vstorea(x::Vec, a, i, mask=nothing) = vstore(x, a, i, nothing, Val(true))
-@propagate_inbounds vstorent(x::Vec, a, i, mask=nothing) = vstore(x, a, i, nothing, Val(true), Val(true))
+@propagate_inbounds vstorea(x::Vec, ptr::Ptr, mask=nothing) = vstore(x, ptr, mask, Val(true))
+@propagate_inbounds vstorent(x::Vec, ptr::Ptr, mask=nothing) = vstore(x, ptr, mask, Val(true), Val(true))
+@propagate_inbounds vstorea(x::Vec, a, i, mask=nothing) = vstore(x, a, i, mask, Val(true))
+@propagate_inbounds vstorent(x::Vec, a, i, mask=nothing) = vstore(x, a, i, mask, Val(true), Val(true))
 
 @inline vloadx(ptr::Ptr, mask::Vec{<:Any, Bool}) =
     Vec(Intrinsics.maskedexpandload(ptr, mask.data))

--- a/src/arrayops.jl
+++ b/src/arrayops.jl
@@ -57,8 +57,9 @@ end
         vload(Vec{N, T}, ptr, mask, Val(Aligned), Val(Nontemporal))
     end
 end
-@propagate_inbounds vloada(::Type{T}, a, i, mask=nothing) where {T<:Vec} = vload(T, a, i, mask, Val(true))
-@propagate_inbounds vloadnt(::Type{T}, a, i, mask=nothing) where {T<:Vec} = vload(T, a, i, mask, Val(true), Val(true))
+@propagate_inbounds vloada(::Type{Vec{N, T}}, ptr::Ptr{T}, mask=nothing) where {N, T} = vload(Vec{N, T}, ptr, mask, Val(true))
+@propagate_inbounds vloada(::Type{Vec{N, T}}, a::FastContiguousArray{T,1}, i::Integer, mask=nothing) where {N, T} = vload(Vec{N, T}, a, i, mask, Val(true))
+@propagate_inbounds vloadnt(::Type{Vec{N, T}}, a::FastContiguousArray{T,1}, i::Integer, mask=nothing) where {N, T} = vload(Vec{N, T}, a, i, mask, Val(true), Val(true))
 
 # vstore
 @propagate_inbounds function vstore(x::Vec{N, T}, ptr::Ptr{T}, mask::Union{Nothing, Vec{N, Bool}}=nothing,
@@ -78,6 +79,7 @@ end
     end
     return a
 end
+@propagate_inbounds vstorea(x::Vec, ptr::Ptr, mask=nothing) = vstore(x, ptr, nothing, Val(true))
 @propagate_inbounds vstorea(x::Vec, a, i, mask=nothing) = vstore(x, a, i, nothing, Val(true))
 @propagate_inbounds vstorent(x::Vec, a, i, mask=nothing) = vstore(x, a, i, nothing, Val(true), Val(true))
 

--- a/src/arrayops.jl
+++ b/src/arrayops.jl
@@ -58,7 +58,7 @@ end
     end
 end
 @propagate_inbounds vloada(::Type{Vec{N, T}}, ptr::Ptr{T}, mask=nothing) where {N, T} = vload(Vec{N, T}, ptr, mask, Val(true))
-@propagate_inbounds vloadnt(::Type{Vec{N, T}}, ptr::Ptr{T}, mask=nothing) where {N, T} = vload(Vec{N, T}, a, i, mask, Val(true), Val(true))
+@propagate_inbounds vloadnt(::Type{Vec{N, T}}, ptr::Ptr{T}, mask=nothing) where {N, T} = vload(Vec{N, T}, ptr, mask, Val(true), Val(true))
 @propagate_inbounds vloada(::Type{Vec{N, T}}, a::FastContiguousArray{T,1}, i::Integer, mask=nothing) where {N, T} = vload(Vec{N, T}, a, i, mask, Val(true))
 @propagate_inbounds vloadnt(::Type{Vec{N, T}}, a::FastContiguousArray{T,1}, i::Integer, mask=nothing) where {N, T} = vload(Vec{N, T}, a, i, mask, Val(true), Val(true))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -359,7 +359,7 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
             @test vloada(V8I32, arri32, i) === V8I32(ntuple(j->i+j-1, L8))
         end
         for i in 1:L8:length(arri32)-(L8-1)
-            @test vloada(V8I32, pointer(arri32) + i-1) === V8I32(ntuple(j->i+j-1, L8))
+            @test vloada(V8I32, pointer(arri32) + sizeof(eltype(V8I32)) * (i-1)) === V8I32(ntuple(j->i+j-1, L8))
         end
         vstorea(V8I32(0), arri32, 1)
         vstore(V8I32(1), arri32, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -396,7 +396,7 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
             ptr = pointer(arr)
             mask = Vec{N,Bool}(ntuple(n->(n & 1), N))
 
-            for (l,s) in zip([vload, vloada, vloada], [vstore, vstorea, vstorent])
+            for (l,s) in zip([vload, vloada, vloadnt], [vstore, vstorea, vstorent])
                 s(vec1, arr, 1)
                 s(vec2, arr, 1+N)
                 @test l(V, arr, 1) === vec1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -406,6 +406,8 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
                 @test l(V, arr, 1) === vec2
                 @test l(V, arr, 1+N) === vec1
                 s(vec1, arr, 1, mask)
+                @test l(V, arr, 1) !== vec1
+                @test l(V, arr, 1) !== vec2
                 @test l(V, arr, 1) === l(V, arr, 1, mask) + l(V, arr, 1, ~mask)
 
                 s(vec1, ptr)
@@ -417,6 +419,8 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
                 @test l(V, ptr) === vec2
                 @test l(V, ptr + sizeof(T) * N) === vec1
                 s(vec1, ptr, mask)
+                @test l(V, ptr) !== vec1
+                @test l(V, ptr) !== vec2
                 @test l(V, ptr) === l(V, ptr, mask) + l(V, ptr, ~mask)
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -374,10 +374,51 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
         for i in 1:4:length(arrf64)-(L4-1)
             @test vloada(V4F64, arrf64, i) === V4F64(ntuple(j->i+j-1, L4))
         end
+        for i in 1:4:length(arrf64)-(L4-1)
+            @test vloada(V4F64, pointer(arrf64) + sizeof(eltype(V4F64)) * (i-1)) === V4F64(ntuple(j->i+j-1, L4))
+        end
         vstorea(V4F64(0), arrf64, 1)
         vstore(V4F64(1), arrf64, 2)
         for i in 1:length(arrf64)
             @test arrf64[i] == if i==1 0 elseif i<=(L4+1) 1 else i end
+        end
+
+
+    end
+
+    @testset "Load and store with pointers" begin
+        for T in [UInt16, Float64], bytes_per_vec in [32, 64]
+            N = bytes_per_vec ÷ sizeof(T)
+            V = Vec{N,T}
+            vec1 = V(ntuple(n->n, N))
+            vec2 = V(ntuple(n->n+N, N))
+            arr = valloc(T, N, 2*N) do _ 0 end
+            ptr = pointer(arr)
+            mask = Vec{N,Bool}(ntuple(n->(n & 1), N))
+
+            for (l,s) in zip([vload, vloada, vloada], [vstore, vstorea, vstorent])
+                s(vec1, arr, 1)
+                s(vec2, arr, 1+N)
+                @test l(V, arr, 1) === vec1
+                @test l(V, arr, 1+N) === vec2
+                s(vec2, arr, 1)
+                s(vec1, arr, 1+N)
+                @test l(V, arr, 1) === vec2
+                @test l(V, arr, 1+N) === vec1
+                s(vec1, arr, 1, mask)
+                @test l(V, arr, 1) === l(V, arr, 1, mask) + l(V, arr, 1, ~mask)
+
+                s(vec1, ptr)
+                s(vec2, ptr + sizeof(T) * N)
+                @test l(V, ptr) === vec1
+                @test l(V, ptr + sizeof(T) * N) === vec2
+                s(vec2, ptr)
+                s(vec1, ptr + sizeof(T) * N)
+                @test l(V, ptr) === vec2
+                @test l(V, ptr + sizeof(T) * N) === vec1
+                s(vec1, ptr, mask)
+                @test l(V, ptr) === l(V, ptr, mask) + l(V, ptr, ~mask)
+            end
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,7 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
     end
 
     @testset "Errors" begin
-        @test_throws ArgumentError("size of conversion type (Int64: 64) must be equal to the vector type (UInt8: 8)") SIMD.Intrinsics.bitcast(Int64,0x1) 
+        @test_throws ArgumentError("size of conversion type (Int64: 64) must be equal to the vector type (UInt8: 8)") SIMD.Intrinsics.bitcast(Int64,0x1)
         @test_throws ArgumentError("size of conversion type (Int64: 64) must be > than the element type (Int64: 64)") SIMD.Intrinsics.trunc(SIMD.LVec{4,Int64}, Vec{4,Int64}((1,2,3,4)).data)
     end
 
@@ -357,6 +357,9 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
         end
         for i in 1:L8:length(arri32)-(L8-1)
             @test vloada(V8I32, arri32, i) === V8I32(ntuple(j->i+j-1, L8))
+        end
+        for i in 1:L8:length(arri32)-(L8-1)
+            @test vloada(V8I32, pointer(arri32) + i-1) === V8I32(ntuple(j->i+j-1, L8))
         end
         vstorea(V8I32(0), arri32, 1)
         vstore(V8I32(1), arri32, 2)


### PR DESCRIPTION
It took me forever to look at the library after the rewrite. Nice work, by the way! I just noticed the `vloada` method I used in a project was not defined anymore. This patch re-introduces it.