### PR TITLE
Fixed the fshl and fshr intrinsics and added bitrotate for Vec objects.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SIMD"
 uuid = "fdea26ae-647d-5447-a871-4b548cad5224"
 authors = ["Erik Schnetter <schnetter@gmail.com>", "Kristoffer Carlsson <kristoffer.carlsson@juliacomputing.com>"]
-version = "3.2.1"
+version = "3.3.0"
 
 [compat]
 julia = "1.5"

--- a/src/LLVM_intrinsics.jl
+++ b/src/LLVM_intrinsics.jl
@@ -111,8 +111,6 @@ const UNARY_INTRINSICS_INT = [
     :bitreverse
     :bswap
     :ctpop
-    :fshl
-    :fshr
 ]
 for (fs, c) in zip([UNARY_INTRINSICS_FLOAT, UNARY_INTRINSICS_INT],
                    [FloatingTypes,          IntegerTypes])
@@ -125,6 +123,23 @@ for (fs, c) in zip([UNARY_INTRINSICS_FLOAT, UNARY_INTRINSICS_INT],
                     ccall($ff, llvmcall, T, (T,), x)
                 )
             end
+        end
+    end
+end
+
+const SHIFT_INTRINSICS_INT = [
+    :fshl
+    :fshr
+]
+
+for f in SHIFT_INTRINSICS_INT
+    @eval begin
+        @generated function $(f)(a::T, b::T, c::T) where T<:LT{<:IntegerTypes}
+            ff = llvm_name($(QuoteNode(f)), T)
+            return :(
+                $(Expr(:meta, :inline));
+                ccall($ff, llvmcall, T, (T,T,T), a, b, c)
+            )
         end
     end
 end

--- a/src/LLVM_intrinsics_old.jl
+++ b/src/LLVM_intrinsics_old.jl
@@ -113,8 +113,6 @@ const UNARY_INTRINSICS_INT = [
     :ctpop
     :ctlz
     :cttz
-    :fshl
-    :fshr
 ]
 for (fs, c) in zip([UNARY_INTRINSICS_FLOAT, UNARY_INTRINSICS_INT],
                    [FloatingTypes,          IntegerTypes])
@@ -130,6 +128,24 @@ for (fs, c) in zip([UNARY_INTRINSICS_FLOAT, UNARY_INTRINSICS_INT],
         end
     end
 end
+
+const SHIFT_INTRINSICS_INT = [
+    :fshl
+    :fshr
+]
+
+for f in SHIFT_INTRINSICS_INT
+    @eval begin
+        @generated function $(f)(a::T, b::T, c::T) where T<:LT{<:IntegerTypes}
+            ff = llvm_name($(QuoteNode(f)), T)
+            return :(
+                $(Expr(:meta, :inline));
+                ccall($ff, llvmcall, T, (T,T,T), a, b, c)
+            )
+        end
+    end
+end
+
 
 # fneg (not an intrinsic so cannot use `ccall)
 @generated function fneg(x::T, ::F=nothing) where {T<:LT{<:FloatingTypes}, F<:FPFlags}

--- a/src/simdvec.jl
+++ b/src/simdvec.jl
@@ -435,6 +435,11 @@ for (op, llvmop) in [(:fma, Intrinsics.fma), (:muladd, Intrinsics.fmuladd)]
     end
 end
 
+if isdefined(Base, :bitrotate)
+    @inline Base.bitrotate(x::Vec, k::Vec) = Vec(Intrinsics.fshl(x.data, x.data, k.data))
+    @inline Base.bitrotate(x::Vec{N, T}, k::Integer) where {N, T} = bitrotate(x, Vec{N, T}(k))
+end
+
 
 ##############
 # Reductions #


### PR DESCRIPTION
This is in response to issue #82.  I tested it on 1.54 and 1.6.0-rc3 and it all works.  1.0.5 crashed, I think in the "Element-wise access" test set, so I don't think that is anything I've done:
`LLVM ERROR: Cannot select: 0x20be2f0: f64 = <<Unknown DAG Node>> ConstantFP:f64<0.000000e+00>, 0x1f512b0`
But the compat section of the Project.toml just says Julia 1.5 so that is probably fine.

Not sure if you would like more indepth tests for the funnel shifts, like test it with various integer types, or if there are specific bit patterns that are a "good" test.

I'm also not sure if I should have included **both** implementations:
```
Base.bitrotate(x::Vec, k::Vec)
Base.bitrotate(x::Vec{N, T}, k::Integer) where {N, T}
```
Would users of bitrotate and vectors expect to rotate all values by the same amount?  Or specify the amount individually with an additional vector?  So maybe the convenience method of taking an integer isn't needed.  It's easy enough to take one or the other out.