### PR TITLE
allow reassociation in fp sum and prod

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SIMD"
 uuid = "fdea26ae-647d-5447-a871-4b548cad5224"
 authors = ["Erik Schnetter <schnetter@gmail.com>", "Kristoffer Carlsson <kristoffer.carlsson@juliacomputing.com>"]
-version = "3.4.0"
+version = "3.4.1"
 
 [compat]
 julia = "1.6"

--- a/src/simdvec.jl
+++ b/src/simdvec.jl
@@ -471,6 +471,8 @@ Base.reduce(F::Any, v::Vec) = error("reduction not defined for SIMD.Vec on $F")
 @inline Base.minimum(v::Vec) = reduce(min, v)
 @inline Base.prod(v::Vec) = reduce(*, v)
 @inline Base.sum(v::Vec) = reduce(+, v)
+@inline Base.prod(v::Vec{<:Any, <:FloatingTypes}) = Intrinsics.reduce_fmul(v.data, Intrinsics.FastMathFlags(Intrinsics.FastMath.reassoc))
+@inline Base.sum(v::Vec{<:Any, <:FloatingTypes}) = Intrinsics.reduce_fadd(v.data, Intrinsics.FastMathFlags(Intrinsics.FastMath.reassoc))
 
 ############
 # Shuffles #


### PR DESCRIPTION
This sould be fair since julia itself uses `@simd` in `sum` and `prod`

Before:

```llvm
julia> using SIMD

julia> dot1(A::Vec{8,Float32},B::Vec{8,Float32}) = sum(A * B)
dot1 (generic function with 1 method)

julia> code_native(dot1, Tuple{Vec{8,Float32}, Vec{8,Float32}})
        .section        __TEXT,__text,regular,pure_instructions
; ┌ @ REPL[2]:1 within `dot1`
; │┌ @ simdvec.jl:253 within `*`
; ││┌ @ LLVM_intrinsics.jl:212 within `fmul` @ LLVM_intrinsics.jl:212
; │││┌ @ LLVM_intrinsics.jl:221 within `macro expansion`
        vmovups (%rdi), %ymm0
        vmulps  (%rsi), %ymm0, %ymm0
        vxorps  %xmm1, %xmm1, %xmm1
; │└└└
; │┌ @ simdvec.jl:473 within `sum`
; ││┌ @ simdvec.jl:463 within `reduce`
; │││┌ @ LLVM_intrinsics.jl:806 within `reduce_fadd`
; ││││┌ @ LLVM_intrinsics.jl:821 within `macro expansion`
        vaddss  %xmm1, %xmm0, %xmm1
        vmovshdup       %xmm0, %xmm2            ## xmm2 = xmm0[1,1,3,3]
        vaddss  %xmm2, %xmm1, %xmm1
        vpermilpd       $1, %xmm0, %xmm2        ## xmm2 = xmm0[1,0]
        vaddss  %xmm2, %xmm1, %xmm1
        vpermilps       $255, %xmm0, %xmm2      ## xmm2 = xmm0[3,3,3,3]
        vaddss  %xmm2, %xmm1, %xmm1
        vextractf128    $1, %ymm0, %xmm0
        vaddss  %xmm0, %xmm1, %xmm1
        vmovshdup       %xmm0, %xmm2            ## xmm2 = xmm0[1,1,3,3]
        vaddss  %xmm2, %xmm1, %xmm1
        vpermilpd       $1, %xmm0, %xmm2        ## xmm2 = xmm0[1,0]
        vaddss  %xmm2, %xmm1, %xmm1
        vpermilps       $255, %xmm0, %xmm0      ## xmm0 = xmm0[3,3,3,3]
        vaddss  %xmm0, %xmm1, %xmm0
; │└└└└
        vzeroupper
        retq
        nopw    %cs:(%rax,%rax)
; └
```

After:

```llvm
julia> code_native(dot1, Tuple{Vec{8,Float32}, Vec{8,Float32}})
        .section        __TEXT,__text,regular,pure_instructions
; ┌ @ REPL[3]:1 within `dot1`
; │┌ @ simdvec.jl:253 within `*`
; ││┌ @ LLVM_intrinsics.jl:212 within `fmul` @ LLVM_intrinsics.jl:212
; │││┌ @ LLVM_intrinsics.jl:221 within `macro expansion`
        vmovups (%rdi), %ymm0
        vmulps  (%rsi), %ymm0, %ymm0
; │└└└
; │┌ @ simdvec.jl:475 within `sum`
; ││┌ @ LLVM_intrinsics.jl:807 within `reduce_fadd`
; │││┌ @ LLVM_intrinsics.jl:823 within `macro expansion`
        vextractf128    $1, %ymm0, %xmm1
        vaddps  %xmm1, %xmm0, %xmm0
        vpermilpd       $1, %xmm0, %xmm1        ## xmm1 = xmm0[1,0]
        vaddps  %xmm1, %xmm0, %xmm0
        vmovshdup       %xmm0, %xmm1            ## xmm1 = xmm0[1,1,3,3]
        vaddss  %xmm1, %xmm0, %xmm0
        vxorps  %xmm1, %xmm1, %xmm1
        vaddss  %xmm1, %xmm0, %xmm0
; │└└└
        vzeroupper
        retq
; └
```

There are still no `vhaddps` instructions as discussed in https://github.com/eschnett/SIMD.jl/issues/91#issue-1097212121. Not sure why. cc @mchristianl 