### PR TITLE
Fix uneven trailing whitespace in strings

### DIFF
--- a/src/LLVM_intrinsics.jl
+++ b/src/LLVM_intrinsics.jl
@@ -271,7 +271,7 @@ for f in BINARY_INTRINSICS_FLOAT
                 %res = call $fpflags $XT @llvm.$ff.$(suffix(N, T))($XT %0, $XT %1)
                 ret $XT %res
             }
-    
+
             attributes #0 = { alwaysinline }
         """
         return :(


### PR DESCRIPTION
Found as part of JuliaLang/julia#46372 - the reference parser treats triple quoted lines of uneven whitespace in a weird inconsistent way so this is changed in the new parser. This change removes the uneven whitespace.