### PR TITLE
fix some shift operations to agree with Base (and prevent undefined behavior)

### DIFF
--- a/src/simdvec.jl
+++ b/src/simdvec.jl
@@ -321,19 +321,19 @@ end
 # Shifting with a value larger than the number of bits in the type is undefined behavior
 # so set to zero in those cases.
 @inline function shl_int(x::Vec{N, T1}, y::Vec{N, T2}) where {N, T1<:IntegerTypes, T2<:IntegerTypes}
-    vifelse(y > sizeof(T1) * 8,
+    vifelse(y >= sizeof(T1) * 8,
         zero(Vec{N, T1}),
         Vec(Intrinsics.shl(x.data, convert(Vec{N,T1}, y).data)))
 end
 
 @inline function lshr_int(x::Vec{N, T1}, y::Vec{N, T2}) where {N, T1<:IntegerTypes, T2<:IntegerTypes}
-    vifelse(y > sizeof(T1) * 8,
+    vifelse(y >= sizeof(T1) * 8,
         zero(Vec{N, T1}),
         Vec(Intrinsics.lshr(x.data, convert(Vec{N,T1}, y).data)))
 end
 
 @inline function ashr_int(x::Vec{N, T1}, y::Vec{N, T2}) where {N, T1<:IntegerTypes, T2<:IntegerTypes}
-    vifelse(y > sizeof(T1) * 8,
+    vifelse(y >= sizeof(T1) * 8,
             Vec(Intrinsics.ashr(x.data, Vec{N,T1}(sizeof(T1)*8-1).data)),
             Vec(Intrinsics.ashr(x.data, Vec{N,T1}(y).data)))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,6 +129,13 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
             end
         end
 
+        f(v) = v << 64
+        f2(v) = v >> 64
+        f3(v) = v >>> 64
+        @test all(f(Vec(1,2,3,4)) == Vec(0,0,0,0))
+        @test all(f2(Vec(1,2,3,4)) == Vec(0,0,0,0))
+        @test all(f3(Vec(1,2,3,4)) == Vec(0,0,0,0))
+
         @test Tuple(V8I32(v8i32)^0) === v8i32.^0
         @test Tuple(V8I32(v8i32)^1) === v8i32.^1
         @test Tuple(V8I32(v8i32)^2) === v8i32.^2


### PR DESCRIPTION
…ehavior)

Due to an off by one, shifting with the exact amount as the number of bits caused garbage to get returned:

```
julia> f2(v) = v >> 64
f2 (generic function with 1 method)

julia> v = Vec(1,2,3,4)
<4 x Int64>[1, 2, 3, 4]

julia> @code_llvm f2(v)
;  @ REPL[25]:1 within `f2`
define void @julia_f2_542([1 x <4 x i64>]* noalias nocapture noundef nonnull sret([1 x <4 x i64>]) align 32 dereferenceable(32) %0, [1 x <4 x i64>]* nocapture noundef nonnull readonly align 16 dereferenceable(32) %1) #0 {
top:
  ret void
}
```

Ref https://discourse.julialang.org/t/simd-struggles-seeking-solutions-with-kangarootwelve-jl/105800/23?u=kristoffer.carlsson