### PR TITLE
Fix (x::Vec)^n  for n>3

### DIFF
--- a/src/LLVM_intrinsics.jl
+++ b/src/LLVM_intrinsics.jl
@@ -293,7 +293,7 @@ end
 
 
 # pow, powi
-for (f, c) in [(:pow, FloatingTypes), (:powi, Union{Int32,Int64,UInt32,UInt64})]
+for (f, c) in [(:pow, FloatingTypes), (:powi, Union{Int32,UInt32})]
     @eval @generated function $(f)(x::T, y::T2) where {T <: LT{<:FloatingTypes}, T2 <: $c}
         ff = llvm_name($(QuoteNode(f)), T)  * "." * suffix(T2)
         return :(

--- a/src/LLVM_intrinsics.jl
+++ b/src/LLVM_intrinsics.jl
@@ -293,7 +293,7 @@ end
 
 
 # pow, powi
-for (f, c) in [(:pow, FloatingTypes), (:powi, Union{Int32,UInt32})]
+for (f, c) in [(:pow, FloatingTypes), (:powi, Union{Int32,Int64,UInt32,UInt64})]
     @eval @generated function $(f)(x::T, y::T2) where {T <: LT{<:FloatingTypes}, T2 <: $c}
         ff = llvm_name($(QuoteNode(f)), T)  * "." * suffix(T2)
         return :(

--- a/src/simdvec.jl
+++ b/src/simdvec.jl
@@ -290,7 +290,17 @@ end
 @inline Base.literal_pow(::typeof(^), x::Vec, ::Val{0}) = one(typeof(x))
 @inline Base.literal_pow(::typeof(^), x::Vec, ::Val{1}) = x
 @inline Base.literal_pow(::typeof(^), x::Vec, ::Val{2}) = x*x
-@inline Base.literal_pow(::typeof(^), x::Vec, ::Val{3}) = x*x*x
+@inline function Base.literal_pow(::typeof(^), x::Vec, ::Val{N}) where N
+    M = div(N,2)
+    N<0 && return inv(Base.literal_pow(^, x, Val(-N)))
+    N<256 && return Base.literal_pow(^, x, Val(M))*Base.literal_pow(^, x, Val(N-M))
+    y, n, xn = one(x), 1, x
+    while n<=N
+        (n&N)==0 || (y = y*xn)
+        n, xn = 2n, xn*xn
+    end
+    y
+end
 
 # Sign
 @inline Base.flipsign(v1::Vec{N,T}, v2::Vec{N,T}) where {N,T} =


### PR DESCRIPTION
Fixes:
```julia
julia> SIMD.Vec(randn(Float64,4)...)^4
ERROR: MethodError: no method matching powi(::NTuple{4, VecElement{Float64}}, ::Int64)
```
Or is there a good reason to not define `powi` for `Int64` exponents ?
