### PR TITLE
WIP: try integrate BFloat16

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Erik Schnetter <schnetter@gmail.com>", "Kristoffer Carlsson <kristof
 version = "3.5.0"
 
 [deps]
+BFloat16s = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]

--- a/src/LLVM_intrinsics.jl
+++ b/src/LLVM_intrinsics.jl
@@ -10,7 +10,7 @@ module Intrinsics
 # when passed to LLVM. It is up to the caller to make sure that the correct
 # intrinsic is called (e.g uitofp vs sitofp).
 
-import ..SIMD: SIMD, VE, LVec, FloatingTypes
+import ..SIMD: SIMD, VE, LVec, FloatingTypes, BFloat16
 # Include Bool in IntegerTypes
 const IntegerTypes = Union{SIMD.IntegerTypes, Bool}
 
@@ -31,6 +31,7 @@ const d = Dict{DataType, String}(
     Float16      => "half",
     Float32      => "float",
     Float64      => "double",
+    BFloat16     => "bfloat",
 )
 # Add the Ptr translations
 # Julia <=1.11 (LLVM <=16) passes `Ptr{T}` as `i64`, Julia >=1.12 (LLVM >=17) passes them as `T*`.

--- a/src/SIMD.jl
+++ b/src/SIMD.jl
@@ -2,6 +2,8 @@ module SIMD
 
 using Base: @propagate_inbounds
 
+using BFloat16s: BFloat16
+
 export Vec, vload, vloada, vloadnt, vloadx, vstore, vstorea, vstorent, vstorec,
        vgather, vgathera, vscatter, vscattera, shufflevector, vifelse, valloc,
        VecRange
@@ -14,7 +16,7 @@ const BIntTypes     = Union{IntTypes, Bool}
 const UIntTypes     = Union{UInt8, UInt16, UInt32, UInt64}
 const IntegerTypes  = Union{IntTypes, UIntTypes}
 const BIntegerTypes = Union{IntegerTypes, Bool}
-const FloatingTypes = Union{Float16, Float32, Float64}
+const FloatingTypes = Union{Float16, Float32, Float64, BFloat16}
 const ScalarTypes   = Union{IntegerTypes, FloatingTypes}
 const VecTypes      = Union{ScalarTypes, Ptr, Bool}
 include("LLVM_intrinsics.jl")


### PR DESCRIPTION
This is just to see how things behave (#123)

```julia-repl
julia> using SIMD, BFloat16s

julia> v = Vec(ntuple(i->BFloat16(rand()), Val(8)))
<8 x BFloat16>[0.796875, 0.56640625, 0.97265625, 0.68359375, 0.26367188, 0.6640625, 0.63671875, 0.8125]

julia> v+v
<8 x BFloat16>[1.59375, 1.1328125, 1.9453125, 1.3671875, 0.52734375, 1.328125, 1.2734375, 1.625]
```

For `v+v` we generate the following LLVM code:

```llvm
%3 = fadd  <8 x bfloat> %0, %1
ret <8 x bfloat> %3
```

but:

```llvm
julia> @code_llvm v+v
; Function Signature: +(SIMD.Vec{8, Core.BFloat16}, SIMD.Vec{8, Core.BFloat16})
;  @ /home/kc/JuliaPkgs/SIMD.jl/src/simdvec.jl:256 within `+`
define void @"julia_+_6263"(ptr noalias nocapture noundef nonnull sret([1 x <8 x bfloat>]) align 16 dereferenceable(16) %sret_return, ptr nocapture noundef nonnull readonly align 16 dereferenceable(16) %"x::Vec", ptr nocapture noundef nonnull readonly align 16 dereferenceable(16) %"y::Vec") #0 {
top:
;  @ /home/kc/JuliaPkgs/SIMD.jl/src/simdvec.jl:257 within `+`
; ┌ @ /home/kc/JuliaPkgs/SIMD.jl/src/LLVM_intrinsics.jl:221 within `fadd` @ /home/kc/JuliaPkgs/SIMD.jl/src/LLVM_intrinsics.jl:221
; │┌ @ /home/kc/JuliaPkgs/SIMD.jl/src/LLVM_intrinsics.jl:231 within `macro expansion`
    %"x::Vec.data_ptr.unbox" = load <8 x bfloat>, ptr %"x::Vec", align 16
    %"y::Vec.data_ptr.unbox" = load <8 x bfloat>, ptr %"y::Vec", align 16
    %0 = fpext <8 x bfloat> %"x::Vec.data_ptr.unbox" to <8 x float>
    %1 = fpext <8 x bfloat> %"y::Vec.data_ptr.unbox" to <8 x float>
    %2 = fadd <8 x float> %0, %1
    %3 = fptrunc <8 x float> %2 to <8 x bfloat>
; └└
; ┌ @ /home/kc/JuliaPkgs/SIMD.jl/src/simdvec.jl:2 within `Vec`
   store <8 x bfloat> %3, ptr %sret_return, align 16
   ret void
; └
}
```



```
julia> versioninfo()
Julia Version 1.12.0-DEV.1013
Commit c767032b8ff (2024-08-08 02:12 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 24 × 12th Gen Intel(R) Core(TM) i9-12900K
  WORD_SIZE: 64
  LLVM: libLLVM-18.1.7 (ORCJIT, alderlake)
```

cc @maleadt 