### PR TITLE
Update test for LLVM 20

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -459,7 +459,7 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
         @test all(Tuple(@fastmath -v) .≈ Tuple(-v))
         f = v -> @fastmath v + v
         # Test that v+v is rewritten as v * 2.0 (change test if optimization changes)
-        @test occursin(r"fmul fast <4 x double> %[^%,]*, <double 2\.000000e\+00", llvm_ir(f, (v,)))
+        @test occursin(r"fmul fast <4 x double> %[^%,]*,.*double 2.000000e\+00", llvm_ir(f, (v,)))
 
         a = Vec{8, Int32}(0)
         @test all((@fastmath a + a) == a)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -459,7 +459,7 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
         @test all(Tuple(@fastmath -v) .≈ Tuple(-v))
         f = v -> @fastmath v + v
         # Test that v+v is rewritten as v * 2.0 (change test if optimization changes)
-        @test occursin(r"fmul fast <4 x double> %[^%,]*,.*double 2.000000e\+00", llvm_ir(f, (v,)))
+        @test occursin(r"fmul fast <4 x double> %[^%,]*,.*double 2\.000000e\+00", llvm_ir(f, (v,)))
 
         a = Vec{8, Int32}(0)
         @test all((@fastmath a + a) == a)


### PR DESCRIPTION
The IR is `fmul fast <4 x double> %\"v::Vec.unbox\", splat (double 2.000000e+00)` on llvm 20.
