### PR TITLE
Remove cbrt, exp10 from supported operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The SIMD package provides the usual arithmetic and logical operations for SIMD v
 
 `+ - * / % ^ ! ~ & | $ << >> >>> == != < <= > >=`
 
-`abs cbrt ceil copysign cos div exp exp10 exp2 flipsign floor fma inv isfinite isinf isnan issubnormal log log10 log2 muladd rem round sign signbit sin sqrt trunc vifelse`
+`abs ceil copysign cos div exp exp2 flipsign floor fma inv isfinite isinf isnan issubnormal log log10 log2 muladd rem round sign signbit sin sqrt trunc vifelse`
 
 (Currently missing: `exponent ldexp significand`, many trigonometric functions)
 


### PR DESCRIPTION
As far as I can tell the `cbrt` and `exp10` functions are not supported for `Vec` inputs, so this PR removes them from the readme.

It looks like an `exp10` intrinsic has been added to llvm (see [here](https://reviews.llvm.org/D157871) and [here](https://llvm.org/docs/LangRef.html#llvm-exp10-intrinsic)) but I don't know if it is supported on the version of LLVM used by julia.