### PR TITLE
fix: make Bool to Float conversions work

### DIFF
--- a/src/simdvec.jl
+++ b/src/simdvec.jl
@@ -48,7 +48,7 @@ Base.copy(v::Vec) = v
             end
         end
     elseif T1 <: FloatingTypes
-        if T2 <: UIntTypes
+        if T2 <: Union{UIntTypes, Bool}
             return Vec(Intrinsics.uitofp(Intrinsics.LVec{N, T1}, v.data))
         elseif T2 <: IntTypes
             return Vec(Intrinsics.sitofp(Intrinsics.LVec{N, T1}, v.data))


### PR DESCRIPTION
Fixes Bool to Float conversions. Before this PR they'd error with "unreachable":
```
julia> convert(SIMD.Vec{4,Float64}, SIMD.Vec{4,Bool}((true,false,true,false)))
ERROR: unreachable
```
After this PR it works as intended.