### PR TITLE
add support for LLVMPtr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          check_bounds: auto
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,15 +81,12 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
-      - uses: julia-actions/julia-buildpkg@v1
-      - name: Checkout OpenCL
+      - name: Remove OpenCL on unsupported platforms
         run: |
-          julia --project -e '
-            using Pkg
-            Pkg.activate("test")
-            Pkg.add(["KernelAbstractions", "OpenCL", "pocl_jll"])
-            rm("test/Manifest.toml")'
-        if: matrix.test-opencl
+          sed -i '/^OpenCL = /d' test/Project.toml
+          sed -i '/^pocl_jll = /d' test/Project.toml
+        if: ${{ ! matrix.test-opencl && matrix.os != 'macOS-latest' }}
+      - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:
           check_bounds: auto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,33 +26,51 @@ jobs:
           - arch: "x64"
             os: "ubuntu-latest"
             version: "~1.12.0-0"
+            test-opencl: true
           - arch: "x64"
             os: "ubuntu-latest"
             version: "1.11"
+            test-opencl: true
+          - arch: "arm64"
+            os: "ubuntu-24.04-arm"
+            version: "1.11"
+            test-opencl: true
           - arch: "x64"
             os: "windows-latest"
             version: "1.11"
+            test-opencl: false
           - arch: "x64"
             os: "macOS-latest"
             version: "1.11"
+            test-opencl: false
+          - arch: "arm64"
+            os: "macOS-latest"
+            version: "1.11"
+            test-opencl: false
           - arch: "x86"
             os: "ubuntu-latest"
             version: "1.11"
+            test-opencl: false
           - arch: "x64"
             os: "ubuntu-latest"
             version: "1.10"
+            test-opencl: true
           - arch: "x64"
             os: "ubuntu-latest"
             version: "1.9"
+            test-opencl: false
           - arch: "x64"
             os: "ubuntu-latest"
             version: "1.8"
+            test-opencl: false
           - arch: "x64"
             os: "ubuntu-latest"
             version: "1.7"
+            test-opencl: false
           - arch: "x64"
             os: "ubuntu-latest"
             version: "1.6"
+            test-opencl: false
           # - arch: "x64"
           #   os: "ubuntu-latest"
           #   version: "nightly"
@@ -63,15 +81,22 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
       - name: Checkout OpenCL
         run: |
           julia --project -e '
             using Pkg
-            Pkg.add(name="OpenCL", rev="sds/validate")'
-      - uses: julia-actions/julia-buildpkg@v1
+            Pkg.add(name="OpenCL", rev="sds/validate")
+            Pkg.activate("test")
+            Pkg.add(name="OpenCL", rev="sds/validate")
+            Pkg.add(["KernelAbstractions", "pocl_jll"])
+            rm("test/Manifest.toml")'
+        if: matrix.test-opencl
       - uses: julia-actions/julia-runtest@v1
         with:
           check_bounds: auto
+        env:
+          TEST_OPENCL: ${{ matrix.test-opencl }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,13 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # See <https://julialang-s3.julialang.org/bin/versions.json> for available Julia versions
         include:
+          - arch: "x64"
+            os: "ubuntu-latest"
+            version: "~1.12.0-0"
           - arch: "x64"
             os: "ubuntu-latest"
             version: "1.11"
@@ -59,6 +63,11 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
+      - name: Checkout OpenCL
+        run: |
+          julia --project -e '
+            using Pkg
+            Pkg.add(name="OpenCL", rev="sds/validate")'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,8 @@ jobs:
         run: |
           julia --project -e '
             using Pkg
-            Pkg.add(name="OpenCL", rev="sds/validate")
             Pkg.activate("test")
-            Pkg.add(name="OpenCL", rev="sds/validate")
-            Pkg.add(["KernelAbstractions", "pocl_jll"])
+            Pkg.add(["KernelAbstractions", "OpenCL", "pocl_jll"])
             rm("test/Manifest.toml")'
         if: matrix.test-opencl
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/ci_julia_nightly.yml
+++ b/.github/workflows/ci_julia_nightly.yml
@@ -41,6 +41,16 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
+      - name: Remove OpenCL on unsupported platforms
+        run: |
+          sed -i '/^OpenCL = /d' test/Project.toml
+          sed -i '/^pocl_jll = /d' test/Project.toml
+        if: ${{ matrix.os != 'macOS-latest' }}
+      - name: Remove OpenCL on unsupported platforms
+        run: |
+          sed -i '' '/^OpenCL = /d' test/Project.toml
+          sed -i '' '/^pocl_jll = /d' test/Project.toml
+        if: ${{ matrix.os == 'macOS-latest' }}
       - uses: julia-actions/julia-runtest@v1
         with:
           check_bounds: auto

--- a/.github/workflows/ci_julia_nightly.yml
+++ b/.github/workflows/ci_julia_nightly.yml
@@ -41,14 +41,11 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
-      - name: Checkout OpenCL
-        run: |
-          julia --project -e '
-            using Pkg
-            Pkg.add(name="OpenCL", rev="sds/validate")'
       - uses: julia-actions/julia-runtest@v1
         with:
           check_bounds: auto
+        env:
+          TEST_OPENCL: false
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         env:

--- a/.github/workflows/ci_julia_nightly.yml
+++ b/.github/workflows/ci_julia_nightly.yml
@@ -42,6 +42,8 @@ jobs:
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          check_bounds: auto
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         env:

--- a/.github/workflows/ci_julia_nightly.yml
+++ b/.github/workflows/ci_julia_nightly.yml
@@ -41,6 +41,11 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
+      - name: Checkout OpenCL
+        run: |
+          julia --project -e '
+            using Pkg
+            Pkg.add(name="OpenCL", rev="sds/validate")'
       - uses: julia-actions/julia-runtest@v1
         with:
           check_bounds: auto

--- a/README.md
+++ b/README.md
@@ -216,6 +216,21 @@ bounds of the array. These boundschecks can be turned off using the `@inbounds`
 macro, e.g. `@inbounds vload(V, a, i)`.  This is often crucial for good
 performance.
 
+### GPU backends
+
+There is experimental support for using `vload`, `vstore`, `vgather` and `vscatter`
+on GPU device arrays with supported backends. Support will vary from backend to
+backend. Currently, only OpenCL.jl is tested in CI. OpenCL by default only support
+`vload` and `vstore` on `CLDeviceArray`s. For `vgather` and `vscatter`, the
+`SPV_INTEL_masked_gather_scatter` extension is required, support for which
+currently requires some workarounds such as using the `:khronos` instead of the
+`:llvm` backend and disabling SPIRV validation. See the tests in
+[`test/opencl.jl`](test/opencl.jl) for some examples.
+
+On GPU backends, using `@inbounds` is essential for good performance, as exceptions
+have a large overhead. Otherwise - so far supported - SIMD operations should work
+just like on the CPU.
+
 ## Vector shuffles
 
 Vector shuffle is available through the `shufflevector` function.

--- a/src/LLVM_intrinsics.jl
+++ b/src/LLVM_intrinsics.jl
@@ -1129,4 +1129,41 @@ end
     )
 end
 
+###################################
+# add_ptr (through getelementptr) #
+###################################
+
+@generated function add_ptr(ptr::LLVMPtr{T, AS}, i::LVec{N, I}) where {T, AS, N, I <: IntegerTypes}
+    s = """
+    %res = getelementptr i8, $(llvm_type(LLVMPtr{UInt8, AS})) %0, <$(N) x $(d[I])> %1
+    ret <$(N) x $(llvm_type(LLVMPtr{UInt8, AS}))> %res
+    """
+    return :(
+        $(Expr(:meta, :inline));
+        Base.llvmcall($s, LVec{N, LLVMPtr{T, AS}}, Tuple{LLVMPtr{T, AS}, LVec{N, I}}, ptr, i)
+    )
+end
+
+@generated function add_ptr(ptr::LVec{N, LLVMPtr{T, AS}}, i::I) where {T, AS, N, I <: IntegerTypes}
+    s = """
+    %res = getelementptr i8, <$(N) x $(llvm_type(LLVMPtr{UInt8, AS}))> %0, $(d[I]) %1
+    ret <$(N) x $(llvm_type(LLVMPtr{UInt8, AS}))> %res
+    """
+    return :(
+        $(Expr(:meta, :inline));
+        Base.llvmcall($s, LVec{N, LLVMPtr{T, AS}}, Tuple{LVec{N, LLVMPtr{T, AS}}, I}, ptr, i)
+    )
+end
+
+@generated function add_ptr(ptr::LVec{N, LLVMPtr{T, AS}}, i::LVec{N, I}) where {T, AS, N, I <: IntegerTypes}
+    s = """
+    %res = getelementptr i8, <$(N) x $(llvm_type(LLVMPtr{UInt8, AS}))> %0, <$(N) x $(d[I])> %1
+    ret <$(N) x $(llvm_type(LLVMPtr{UInt8, AS}))> %res
+    """
+    return :(
+        $(Expr(:meta, :inline));
+        Base.llvmcall($s, LVec{N, LLVMPtr{T, AS}}, Tuple{LVec{N, LLVMPtr{T, AS}}, LVec{N, I}}, ptr, i)
+    )
+end
+
 end

--- a/src/LLVM_intrinsics.jl
+++ b/src/LLVM_intrinsics.jl
@@ -11,6 +11,7 @@ module Intrinsics
 # intrinsic is called (e.g uitofp vs sitofp).
 
 import ..SIMD: SIMD, VE, LVec, FloatingTypes
+using Core: LLVMPtr
 # Include Bool in IntegerTypes
 const IntegerTypes = Union{SIMD.IntegerTypes, Bool}
 
@@ -58,6 +59,11 @@ llvm_name(llvmf, ::Type{T}) where {T}            = string("llvm", ".", dotit(llv
 
 llvm_type(::Type{T}) where {T}            = d[T]
 llvm_type(::Type{LVec{N, T}}) where {N,T} = "<$N x $(d[T])>"
+@static if VERSION >= v"1.12-DEV"
+    llvm_type(::Type{LLVMPtr{T, AS}}) where {T, AS} = "ptr addrspace($AS)"
+else
+    llvm_type(::Type{LLVMPtr{T, AS}}) where {T, AS} = "$(llvm_type(T)) addrspace($AS)*"
+end
 
 ############
 # FastMath #
@@ -480,6 +486,19 @@ temporal_str(temporal) = temporal ? ", !nontemporal !{i32 1}" : ""
     )
 end
 
+@generated function load(x::Type{LVec{N, T}}, ptr::LLVMPtr{T, AS},
+                         ::Val{Al}=Val(false), ::Val{Te}=Val(false)) where {N, T, AS, Al, Te}
+    s = """
+    %ptr = bitcast $(llvm_type(LLVMPtr{UInt8, AS})) %0 to $(llvm_type(LLVMPtr{LVec{N, T}, AS}))
+    %res = load <$N x $(d[T])>, $(llvm_type(LLVMPtr{LVec{N, T}, AS})) %ptr, align $(n_align(Al, N, T)) $(temporal_str(Te))
+    ret <$N x $(d[T])> %res
+    """
+    return :(
+        $(Expr(:meta, :inline));
+        Base.llvmcall($s, LVec{N, T}, Tuple{LLVMPtr{T, AS}}, ptr)
+    )
+end
+
 @generated function maskedload(ptr::Ptr{T}, mask::LVec{N,Bool},
                                ::Val{Al}=Val(false), ::Val{Te}=Val(false)) where {N, T, Al, Te}
     # TODO: Allow setting the passthru
@@ -502,6 +521,28 @@ end
     )
 end
 
+@generated function maskedload(ptr::LLVMPtr{T, AS}, mask::LVec{N,Bool},
+                               ::Val{Al}=Val(false), ::Val{Te}=Val(false)) where {N, T, AS, Al, Te}
+    # TODO: Allow setting the passthru
+    mod = """
+        declare <$N x $(d[T])> @llvm.masked.load.$(suffix(N, T))($(llvm_type(LLVMPtr{LVec{N, T}, AS})), i32, <$N x i1>, <$N x $(d[T])>)
+
+        define <$N x $(d[T])> @entry($(llvm_type(LLVMPtr{UInt8, AS})), <$(N) x i8>) #0 {
+        top:
+            %mask = trunc <$(N) x i8> %1 to <$(N) x i1>
+            %ptr = bitcast $(llvm_type(LLVMPtr{UInt8, AS})) %0 to $(llvm_type(LLVMPtr{LVec{N, T}, AS}))
+            %res = call <$N x $(d[T])> @llvm.masked.load.$(suffix(N, T))($(llvm_type(LLVMPtr{LVec{N, T}, AS})) %ptr, i32 $(n_align(Al, N, T)), <$N x i1> %mask, <$N x $(d[T])> zeroinitializer)
+            ret <$N x $(d[T])> %res
+        }
+
+        attributes #0 = { alwaysinline }
+    """
+    return :(
+        $(Expr(:meta, :inline));
+        Base.llvmcall(($mod, "entry"), LVec{N, T}, Tuple{LLVMPtr{T, AS}, LVec{N,Bool}}, ptr, mask)
+    )
+end
+
 @generated function store(x::LVec{N, T}, ptr::Ptr{T},
                           ::Val{Al}=Val(false), ::Val{Te}=Val(false)) where {N, T, Al, Te}
     s = """
@@ -513,6 +554,20 @@ end
 
         $(Expr(:meta, :inline));
         Base.llvmcall($s, Cvoid, Tuple{LVec{N, T}, Ptr{T}}, x, ptr)
+    )
+end
+
+@generated function store(x::LVec{N, T}, ptr::LLVMPtr{T, AS},
+                          ::Val{Al}=Val(false), ::Val{Te}=Val(false)) where {N, T, AS, Al, Te}
+    s = """
+    %ptr = bitcast $(llvm_type(LLVMPtr{UInt8, AS})) %1 to $(llvm_type(LLVMPtr{LVec{N, T}, AS}))
+    store <$N x $(d[T])> %0, $(llvm_type(LLVMPtr{LVec{N, T}, AS})) %ptr, align $(n_align(Al, N, T)) $(temporal_str(Te))
+    ret void
+    """
+    return :(
+
+        $(Expr(:meta, :inline));
+        Base.llvmcall($s, Cvoid, Tuple{LVec{N, T}, LLVMPtr{T, AS}}, x, ptr)
     )
 end
 
@@ -538,6 +593,29 @@ end
     )
 end
 
+@generated function maskedstore(x::LVec{N, T}, ptr::LLVMPtr{T, AS}, mask::LVec{N,Bool},
+                               ::Val{Al}=Val(false), ::Val{Te}=Val(false)) where {N, T, AS, Al, Te}
+    # TODO: Allow setting the passthru
+    mod = """
+        declare void @llvm.masked.store.$(suffix(N, T))(<$N x $(d[T])>, $(llvm_type(LLVMPtr{LVec{N, T}, AS})), i32, <$N x i1>)
+
+        define void @entry(<$N x $(d[T])>, $(llvm_type(LLVMPtr{UInt8, AS})), <$(N) x i8>) #0 {
+        top:
+            %mask = trunc <$(N) x i8> %2 to <$(N) x i1>
+            %ptr = bitcast $(llvm_type(LLVMPtr{UInt8, AS})) %1 to $(llvm_type(LLVMPtr{LVec{N, T}, AS}))
+            call void @llvm.masked.store.$(suffix(N, T))(<$N x $(d[T])> %0, $(llvm_type(LLVMPtr{LVec{N, T}, AS})) %ptr, i32 $(n_align(Al, N, T)), <$N x i1> %mask)
+            ret void
+        }
+
+        attributes #0 = { alwaysinline }
+    """
+    return :(
+        $(Expr(:meta, :inline));
+        Base.llvmcall(($mod, "entry"), Cvoid, Tuple{LVec{N, T}, LLVMPtr{T, AS}, LVec{N,Bool}}, x, ptr, mask)
+    )
+end
+
+
 @generated function maskedexpandload(ptr::Ptr{T}, mask::LVec{N,Bool}) where {N, T}
     # TODO: Allow setting the passthru
     mod = """
@@ -559,6 +637,28 @@ end
     )
 end
 
+@generated function maskedexpandload(ptr::LLVMPtr{T, AS}, mask::LVec{N,Bool}) where {N, T, AS}
+    # TODO: Allow setting the passthru
+    mod = """
+        declare <$N x $(d[T])> @llvm.masked.expandload.$(suffix(N, T))($(llvm_type(LLVMPtr{T, AS})), <$N x i1>, <$N x $(d[T])>)
+
+        define <$N x $(d[T])> @entry($(llvm_type(LLVMPtr{UInt8, AS})), <$(N) x i8>) #0 {
+        top:
+            %mask = trunc <$(N) x i8> %1 to <$(N) x i1>
+            %ptr = bitcast $(llvm_type(LLVMPtr{UInt8, AS})) %0 to $(llvm_type(LLVMPtr{T, AS}))
+            %res = call <$N x $(d[T])> @llvm.masked.expandload.$(suffix(N, T))($(llvm_type(LLVMPtr{T, AS})) %ptr, <$N x i1> %mask, <$N x $(d[T])> zeroinitializer)
+            ret <$N x $(d[T])> %res
+        }
+
+        attributes #0 = { alwaysinline }
+    """
+    return :(
+        $(Expr(:meta, :inline));
+        Base.llvmcall(($mod, "entry"), LVec{N, T}, Tuple{LLVMPtr{T, AS}, LVec{N, Bool}}, ptr, mask)
+    )
+end
+
+
 @generated function maskedcompressstore(x::LVec{N, T}, ptr::Ptr{T},
                                         mask::LVec{N,Bool}) where {N, T}
     mod = """
@@ -577,6 +677,27 @@ end
     return :(
         $(Expr(:meta, :inline));
         Base.llvmcall(($mod, "entry"), Cvoid, Tuple{LVec{N, T}, Ptr{T}, LVec{N, Bool}}, x, ptr, mask)
+    )
+end
+
+@generated function maskedcompressstore(x::LVec{N, T}, ptr::LLVMPtr{T, AS},
+                                        mask::LVec{N,Bool}) where {N, T, AS}
+    mod = """
+        declare void @llvm.masked.compressstore.$(suffix(N, T))(<$N x $(d[T])>, $(llvm_type(LLVMPtr{T, AS})), <$N x i1>)
+
+        define void @entry(<$N x $(d[T])>, $(llvm_type(LLVMPtr{UInt8, AS})), <$(N) x i8>) #0 {
+        top:
+            %mask = trunc <$(N) x i8> %2 to <$(N) x i1>
+            %ptr = bitcast $(llvm_type(LLVMPtr{UInt8, AS})) %1 to $(llvm_type(LLVMPtr{T, AS}))
+            call void @llvm.masked.compressstore.$(suffix(N, T))(<$N x $(d[T])> %0, $(llvm_type(LLVMPtr{T, AS})) %ptr, <$N x i1> %mask)
+            ret void
+        }
+
+        attributes #0 = { alwaysinline }
+    """
+    return :(
+        $(Expr(:meta, :inline));
+        Base.llvmcall(($mod, "entry"), Cvoid, Tuple{LVec{N, T}, LLVMPtr{T, AS}, LVec{N, Bool}}, x, ptr, mask)
     )
 end
 
@@ -607,6 +728,29 @@ end
     )
 end
 
+@generated function maskedgather(ptrs::LVec{N,LLVMPtr{T, AS}},
+                                 mask::LVec{N,Bool}, ::Val{Al}=Val(false)) where {N, T, AS, Al}
+    # TODO: Allow setting the passthru
+    mod = """
+        declare <$N x $(d[T])> @llvm.masked.gather.$(suffix(N, T))(<$N x $(llvm_type(LLVMPtr{T, AS}))>, i32, <$N x i1>, <$N x $(d[T])>)
+
+        define <$N x $(d[T])> @entry(<$N x $(llvm_type(LLVMPtr{UInt8, AS}))>, <$(N) x i8>) #0 {
+        top:
+            %mask = trunc <$(N) x i8> %1 to <$(N) x i1>
+            %ptrs = bitcast <$N x $(llvm_type(LLVMPtr{UInt8, AS}))> %0 to <$N x $(llvm_type(LLVMPtr{T, AS}))>
+            %res = call <$N x $(d[T])> @llvm.masked.gather.$(suffix(N, T))(<$N x $(llvm_type(LLVMPtr{T, AS}))> %ptrs, i32 $(n_align(Al, N, T)), <$N x i1> %mask, <$N x $(d[T])> zeroinitializer)
+            ret <$N x $(d[T])> %res
+        }
+
+        attributes #0 = { alwaysinline }
+    """
+    return :(
+        $(Expr(:meta, :inline));
+        Base.llvmcall(($mod, "entry"), LVec{N, T}, Tuple{LVec{N, LLVMPtr{T, AS}}, LVec{N, Bool}}, ptrs, mask)
+    )
+end
+
+
 @generated function maskedscatter(x::LVec{N, T}, ptrs::LVec{N, Ptr{T}},
                                   mask::LVec{N,Bool}, ::Val{Al}=Val(false)) where {N, T, Al}
     mod = """
@@ -625,6 +769,27 @@ end
     return :(
         $(Expr(:meta, :inline));
         Base.llvmcall(($mod, "entry"), Cvoid, Tuple{LVec{N, T}, LVec{N, Ptr{T}}, LVec{N, Bool}}, x, ptrs, mask)
+    )
+end
+
+@generated function maskedscatter(x::LVec{N, T}, ptrs::LVec{N, LLVMPtr{T, AS}},
+                                  mask::LVec{N,Bool}, ::Val{Al}=Val(false)) where {N, T, AS, Al}
+    mod = """
+        declare void @llvm.masked.scatter.$(suffix(N, T))(<$N x $(d[T])>, <$N x $(llvm_type(LLVMPtr{T, AS}))>, i32, <$N x i1>)
+
+        define void @entry(<$N x $(d[T])>, <$N x $(llvm_type(LLVMPtr{UInt8, AS}))>, <$(N) x i8>) #0 {
+        top:
+            %mask = trunc <$(N) x i8> %2 to <$(N) x i1>
+            %ptrs = bitcast <$N x $(llvm_type(LLVMPtr{UInt8, AS}))> %1 to <$N x $(llvm_type(LLVMPtr{T, AS}))>
+            call void @llvm.masked.scatter.$(suffix(N, T))(<$N x $(d[T])> %0, <$N x $(llvm_type(LLVMPtr{T, AS}))> %ptrs, i32 $(n_align(Al, N, T)), <$N x i1> %mask)
+            ret void
+        }
+
+        attributes #0 = { alwaysinline }
+    """
+    return :(
+        $(Expr(:meta, :inline));
+        Base.llvmcall(($mod, "entry"), Cvoid, Tuple{LVec{N, T}, LVec{N, LLVMPtr{T, AS}}, LVec{N, Bool}}, x, ptrs, mask)
     )
 end
 
@@ -771,6 +936,17 @@ end
     )
 end
 
+@generated function inttoptr(::Type{LVec{N, LLVMPtr{T2, AS}}}, x::LVec{N, T1}) where {N, T1 <: IntegerTypes, T2 <: Union{IntegerTypes, FloatingTypes}, AS}
+    s = """
+    %2 = inttoptr <$(N) x $(d[T1])> %0 to <$(N) x $(llvm_type(LLVMPtr{UInt8, AS}))>
+    ret <$(N) x $(llvm_type(LLVMPtr{UInt8, AS}))> %2
+    """
+    return :(
+        $(Expr(:meta, :inline));
+        Base.llvmcall($s, LVec{N, LLVMPtr{T2, AS}}, Tuple{LVec{N, T1}}, x)
+    )
+end
+
 @generated function ptrtoint(::Type{LVec{N, T2}}, x::LVec{N, Ptr{T1}}) where {N, T1 <: Union{IntegerTypes, FloatingTypes}, T2 <: IntegerTypes}
     convert = VERSION >= v"1.12-DEV" ? "ptrtoint" : "bitcast"
     s = """
@@ -780,6 +956,17 @@ end
     return :(
         $(Expr(:meta, :inline));
         Base.llvmcall($s, LVec{N, T2}, Tuple{LVec{N, Ptr{T1}}}, x)
+    )
+end
+
+@generated function ptrtoint(::Type{LVec{N, T2}}, x::LVec{N, LLVMPtr{T1, AS}}) where {N, T1 <: Union{IntegerTypes, FloatingTypes}, T2 <: IntegerTypes, AS}
+    s = """
+    %2 = ptrtoint <$(N) x $(llvm_type(LLVMPtr{UInt8, AS}))> %0 to <$(N) x $(d[T2])>
+    ret <$(N) x $(d[T2])> %2
+    """
+    return :(
+        $(Expr(:meta, :inline));
+        Base.llvmcall($s, LVec{N, T2}, Tuple{LVec{N, LLVMPtr{T1, AS}}}, x)
     )
 end
 

--- a/src/SIMD.jl
+++ b/src/SIMD.jl
@@ -1,6 +1,7 @@
 module SIMD
 
 using Base: @propagate_inbounds
+using Core: LLVMPtr
 
 export Vec, vload, vloada, vloadnt, vloadx, vstore, vstorea, vstorent, vstorec,
        vgather, vgathera, vscatter, vscattera, shufflevector, vifelse, valloc,
@@ -16,7 +17,7 @@ const IntegerTypes  = Union{IntTypes, UIntTypes}
 const BIntegerTypes = Union{IntegerTypes, Bool}
 const FloatingTypes = Union{Float16, Float32, Float64}
 const ScalarTypes   = Union{IntegerTypes, FloatingTypes}
-const VecTypes      = Union{ScalarTypes, Ptr, Bool}
+const VecTypes      = Union{ScalarTypes, Ptr, LLVMPtr, Bool}
 include("LLVM_intrinsics.jl")
 include("simdvec.jl")
 include("arrayops.jl")

--- a/src/SIMD.jl
+++ b/src/SIMD.jl
@@ -9,6 +9,7 @@ export Vec, vload, vloada, vloadnt, vloadx, vstore, vstorea, vstorent, vstorec,
 
 const VE         = Base.VecElement
 const LVec{N, T} = NTuple{N, VE{T}}
+const AnyPtr{T}  = Union{Ptr{T}, LLVMPtr{T}}
 
 const IntTypes      = Union{Int8, Int16, Int32, Int64} # Int128 and UInt128 does not get passed as LLVM vectors
 const BIntTypes     = Union{IntTypes, Bool}

--- a/src/arrayops.jl
+++ b/src/arrayops.jl
@@ -85,12 +85,12 @@ end
     end
     return a
 end
-@propagate_inbounds vstorea(x::Vec, ptr::Union{Ptr, LLVMPtr}, mask=nothing) = vstore(x, ptr, mask, Val(true))
-@propagate_inbounds vstorent(x::Vec, ptr::Union{Ptr, LLVMPtr}, mask=nothing) = vstore(x, ptr, mask, Val(true), Val(true))
+@propagate_inbounds vstorea(x::Vec, ptr::AnyPtr, mask=nothing) = vstore(x, ptr, mask, Val(true))
+@propagate_inbounds vstorent(x::Vec, ptr::AnyPtr, mask=nothing) = vstore(x, ptr, mask, Val(true), Val(true))
 @propagate_inbounds vstorea(x::Vec, a, i, mask=nothing) = vstore(x, a, i, mask, Val(true))
 @propagate_inbounds vstorent(x::Vec, a, i, mask=nothing) = vstore(x, a, i, mask, Val(true), Val(true))
 
-@inline vloadx(ptr::Union{Ptr, LLVMPtr}, mask::Vec{<:Any, Bool}) =
+@inline vloadx(ptr::AnyPtr, mask::Vec{<:Any, Bool}) =
     Vec(Intrinsics.maskedexpandload(ptr, mask.data))
 
 @propagate_inbounds function vloadx(a::FastContiguousArray{T,1},
@@ -153,7 +153,7 @@ end
                  mask::Vec{N,Bool}=one(Vec{N,Bool}),
                  ::Val{Aligned}=Val(false)) where {N, T<:ScalarTypes, Aligned} =
     return Vec(Intrinsics.maskedgather(ptrs.data, mask.data))
-@inline vgather(ptrs::Vec{<:Any,<:Union{Ptr{<:ScalarTypes}, LLVMPtr{<:ScalarTypes}}}, ::Nothing, aligned::Val = Val(false)) =
+@inline vgather(ptrs::Vec{<:Any,<:AnyPtr{<:ScalarTypes}}, ::Nothing, aligned::Val = Val(false)) =
     vgather(ptrs, one(Vec{length(ptrs),Bool}), aligned)
 @propagate_inbounds function vgather(a::FastContiguousArray{T,1}, idx::Vec{N, <:Integer},
                                      mask::Vec{N,Bool}=one(Vec{N,Bool}),

--- a/src/arrayops.jl
+++ b/src/arrayops.jl
@@ -1,4 +1,5 @@
 using Base: Slice, ScalarIndex
+using Core: LLVMPtr
 
 """
     ContiguousSubArray{T,N,P,I,L}
@@ -44,7 +45,7 @@ FastContiguousArray{T,N} = Union{DenseArray{T,N}, Base.FastContiguousSubArray{T,
 # https://github.com/JuliaArrays/MappedArrays.jl/pull/24#issuecomment-460568978
 
 # vload
-@propagate_inbounds function vload(::Type{Vec{N, T}}, ptr::Ptr{T}, mask::Union{Nothing, Vec{N, Bool}}=nothing,
+@propagate_inbounds function vload(::Type{Vec{N, T}}, ptr::Union{Ptr{T}, LLVMPtr{T}}, mask::Union{Nothing, Vec{N, Bool}}=nothing,
                        ::Val{Aligned}=Val(false), ::Val{Nontemporal}=Val(false)) where {N, T, Aligned, Nontemporal}
     if mask === nothing
         Vec(Intrinsics.load(Intrinsics.LVec{N, T}, ptr, Val(Aligned), Val(Nontemporal)))
@@ -61,13 +62,13 @@ end
         vload(Vec{N, T}, ptr, mask, Val(Aligned), Val(Nontemporal))
     end
 end
-@propagate_inbounds vloada(::Type{Vec{N, T}}, ptr::Ptr{T}, mask=nothing) where {N, T} = vload(Vec{N, T}, ptr, mask, Val(true))
-@propagate_inbounds vloadnt(::Type{Vec{N, T}}, ptr::Ptr{T}, mask=nothing) where {N, T} = vload(Vec{N, T}, ptr, mask, Val(true), Val(true))
+@propagate_inbounds vloada(::Type{Vec{N, T}}, ptr::Union{Ptr{T}, LLVMPtr{T}}, mask=nothing) where {N, T} = vload(Vec{N, T}, ptr, mask, Val(true))
+@propagate_inbounds vloadnt(::Type{Vec{N, T}}, ptr::Union{Ptr{T}, LLVMPtr{T}}, mask=nothing) where {N, T} = vload(Vec{N, T}, ptr, mask, Val(true), Val(true))
 @propagate_inbounds vloada(::Type{Vec{N, T}}, a::FastContiguousArray{T,1}, i::Integer, mask=nothing) where {N, T} = vload(Vec{N, T}, a, i, mask, Val(true))
 @propagate_inbounds vloadnt(::Type{Vec{N, T}}, a::FastContiguousArray{T,1}, i::Integer, mask=nothing) where {N, T} = vload(Vec{N, T}, a, i, mask, Val(true), Val(true))
 
 # vstore
-@propagate_inbounds function vstore(x::Vec{N, T}, ptr::Ptr{T}, mask::Union{Nothing, Vec{N, Bool}}=nothing,
+@propagate_inbounds function vstore(x::Vec{N, T}, ptr::Union{Ptr{T}, LLVMPtr{T}}, mask::Union{Nothing, Vec{N, Bool}}=nothing,
                        ::Val{Aligned}=Val(false), ::Val{Nontemporal}=Val(false)) where {N, T, Aligned, Nontemporal}
     if mask === nothing
         Intrinsics.store(x.data, ptr, Val(Aligned), Val(Nontemporal))
@@ -84,12 +85,12 @@ end
     end
     return a
 end
-@propagate_inbounds vstorea(x::Vec, ptr::Ptr, mask=nothing) = vstore(x, ptr, mask, Val(true))
-@propagate_inbounds vstorent(x::Vec, ptr::Ptr, mask=nothing) = vstore(x, ptr, mask, Val(true), Val(true))
+@propagate_inbounds vstorea(x::Vec, ptr::Union{Ptr, LLVMPtr}, mask=nothing) = vstore(x, ptr, mask, Val(true))
+@propagate_inbounds vstorent(x::Vec, ptr::Union{Ptr, LLVMPtr}, mask=nothing) = vstore(x, ptr, mask, Val(true), Val(true))
 @propagate_inbounds vstorea(x::Vec, a, i, mask=nothing) = vstore(x, a, i, mask, Val(true))
 @propagate_inbounds vstorent(x::Vec, a, i, mask=nothing) = vstore(x, a, i, mask, Val(true), Val(true))
 
-@inline vloadx(ptr::Ptr, mask::Vec{<:Any, Bool}) =
+@inline vloadx(ptr::Union{Ptr, LLVMPtr}, mask::Vec{<:Any, Bool}) =
     Vec(Intrinsics.maskedexpandload(ptr, mask.data))
 
 @propagate_inbounds function vloadx(a::FastContiguousArray{T,1},
@@ -101,7 +102,7 @@ end
     end
 end
 
-@inline vstorec(x::Vec{N, T}, ptr::Ptr{T}, mask::Vec{N, Bool}) where {N, T} =
+@inline vstorec(x::Vec{N, T}, ptr::Union{Ptr{T}, LLVMPtr{T}}, mask::Vec{N, Bool}) where {N, T} =
     Intrinsics.maskedcompressstore(x.data, ptr, mask.data)
 
 @propagate_inbounds function vstorec(x::Vec{N, T}, a::FastContiguousArray{T,1},
@@ -141,20 +142,20 @@ function valloc(f, ::Type{T}, N::Int, sz::Int) where T
     mem
 end
 
-@inline function _get_vec_pointers(a, idx::Vec{N, Int}) where {N}
+@inline function _get_vec_pointers(a, idx::Vec{N, <:Integer}) where {N}
     ptrs = pointer(a) + (idx - 1) * sizeof(eltype(a))
 end
 
 # Have to be careful with optional arguments and @boundscheck,
 # see https://github.com/JuliaLang/julia/issues/30411,
 # therefore use @propagate_inbounds
-@inline vgather(ptrs::Vec{N,Ptr{T}},
+@inline vgather(ptrs::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}},
                  mask::Vec{N,Bool}=one(Vec{N,Bool}),
                  ::Val{Aligned}=Val(false)) where {N, T<:ScalarTypes, Aligned} =
     return Vec(Intrinsics.maskedgather(ptrs.data, mask.data))
-@inline vgather(ptrs::Vec{<:Any,<:Ptr{<:ScalarTypes}}, ::Nothing, aligned::Val = Val(false)) =
+@inline vgather(ptrs::Vec{<:Any,<:Union{Ptr{<:ScalarTypes}, LLVMPtr{<:ScalarTypes}}}, ::Nothing, aligned::Val = Val(false)) =
     vgather(ptrs, one(Vec{length(ptrs),Bool}), aligned)
-@propagate_inbounds function vgather(a::FastContiguousArray{T,1}, idx::Vec{N, Int},
+@propagate_inbounds function vgather(a::FastContiguousArray{T,1}, idx::Vec{N, <:Integer},
                                      mask::Vec{N,Bool}=one(Vec{N,Bool}),
                                      ::Val{Aligned}=Val(false)) where {N, T<:ScalarTypes, Aligned}
     @boundscheck for i in 1:N
@@ -167,18 +168,20 @@ end
 end
 @propagate_inbounds vgathera(a, idx, mask) = vgather(a, idx, mask, Val(true))
 @propagate_inbounds vgathera(a, idx::Vec{N}) where {N} = vgather(a, idx, one(Vec{N,Bool}), Val(true))
+@propagate_inbounds vgathera(ptrs::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}, mask::Vec{N,Bool}) where {N,T} = vgather(ptrs, mask, Val(true))
+@propagate_inbounds vgathera(ptrs::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}) where {N,T} = vgather(ptrs, one(Vec{N,Bool}), Val(true))
 
-@propagate_inbounds Base.getindex(a::FastContiguousArray{T,1}, idx::Vec{N,Int}) where {N,T} =
+@propagate_inbounds Base.getindex(a::FastContiguousArray{T,1}, idx::Vec{N,<:Integer}) where {N,T} =
     vgather(a, idx)
 
 
-@propagate_inbounds vscatter(x::Vec{N,T}, ptrs::Vec{N,Ptr{T}},
+@propagate_inbounds vscatter(x::Vec{N,T}, ptrs::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}},
                              mask::Vec{N,Bool}, ::Val{Aligned}=Val(false)) where {N, T<:ScalarTypes, Aligned} =
     Intrinsics.maskedscatter(x.data, ptrs.data, mask.data)
-@inline vscatter(x::Vec{N,T}, ptrs::Vec{N,Ptr{T}},
+@inline vscatter(x::Vec{N,T}, ptrs::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}},
                  ::Nothing, aligned::Val=Val(false)) where {N, T<:ScalarTypes} =
     vscatter(x, ptrs, one(Vec{N, Bool}), aligned)
-@propagate_inbounds function vscatter(x::Vec{N,T}, a::FastContiguousArray{T,1}, idx::Vec{N, Int},
+@propagate_inbounds function vscatter(x::Vec{N,T}, a::FastContiguousArray{T,1}, idx::Vec{N, <:Integer},
                                       mask::Vec{N,Bool}=one(Vec{N, Bool}),
                                       ::Val{Aligned}=Val(false)) where {N, T<:ScalarTypes, Aligned}
     @boundscheck for i in 1:N
@@ -192,8 +195,10 @@ end
 end
 @propagate_inbounds vscattera(x, a, idx, mask) = vscatter(x, a, idx, mask, Val(true))
 @propagate_inbounds vscattera(x, a, idx::Vec{N}) where {N}  = vscatter(x, a, idx, one(Vec{N,Bool}), Val(true))
+@propagate_inbounds vscattera(x::Vec{N,T}, ptrs::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}, mask::Vec{N,Bool}) where {N,T} = vscatter(x, ptrs, mask, Val(true))
+@propagate_inbounds vscattera(x::Vec{N,T}, ptrs::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}) where {N,T} = vscatter(x, ptrs, one(Vec{N,Bool}), Val(true))
 
-@propagate_inbounds Base.setindex!(a::FastContiguousArray{T,1}, v::Vec{N,T}, idx::Vec{N,Int}) where {N, T} =
+@propagate_inbounds Base.setindex!(a::FastContiguousArray{T,1}, v::Vec{N,T}, idx::Vec{N,<:Integer}) where {N, T} =
     vscatter(v, a, idx)
 
 

--- a/src/arrayops.jl
+++ b/src/arrayops.jl
@@ -45,7 +45,7 @@ FastContiguousArray{T,N} = Union{DenseArray{T,N}, Base.FastContiguousSubArray{T,
 # https://github.com/JuliaArrays/MappedArrays.jl/pull/24#issuecomment-460568978
 
 # vload
-@propagate_inbounds function vload(::Type{Vec{N, T}}, ptr::Union{Ptr{T}, LLVMPtr{T}}, mask::Union{Nothing, Vec{N, Bool}}=nothing,
+@propagate_inbounds function vload(::Type{Vec{N, T}}, ptr::AnyPtr{T}, mask::Union{Nothing, Vec{N, Bool}}=nothing,
                        ::Val{Aligned}=Val(false), ::Val{Nontemporal}=Val(false)) where {N, T, Aligned, Nontemporal}
     if mask === nothing
         Vec(Intrinsics.load(Intrinsics.LVec{N, T}, ptr, Val(Aligned), Val(Nontemporal)))
@@ -62,13 +62,13 @@ end
         vload(Vec{N, T}, ptr, mask, Val(Aligned), Val(Nontemporal))
     end
 end
-@propagate_inbounds vloada(::Type{Vec{N, T}}, ptr::Union{Ptr{T}, LLVMPtr{T}}, mask=nothing) where {N, T} = vload(Vec{N, T}, ptr, mask, Val(true))
-@propagate_inbounds vloadnt(::Type{Vec{N, T}}, ptr::Union{Ptr{T}, LLVMPtr{T}}, mask=nothing) where {N, T} = vload(Vec{N, T}, ptr, mask, Val(true), Val(true))
+@propagate_inbounds vloada(::Type{Vec{N, T}}, ptr::AnyPtr{T}, mask=nothing) where {N, T} = vload(Vec{N, T}, ptr, mask, Val(true))
+@propagate_inbounds vloadnt(::Type{Vec{N, T}}, ptr::AnyPtr{T}, mask=nothing) where {N, T} = vload(Vec{N, T}, ptr, mask, Val(true), Val(true))
 @propagate_inbounds vloada(::Type{Vec{N, T}}, a::FastContiguousArray{T,1}, i::Integer, mask=nothing) where {N, T} = vload(Vec{N, T}, a, i, mask, Val(true))
 @propagate_inbounds vloadnt(::Type{Vec{N, T}}, a::FastContiguousArray{T,1}, i::Integer, mask=nothing) where {N, T} = vload(Vec{N, T}, a, i, mask, Val(true), Val(true))
 
 # vstore
-@propagate_inbounds function vstore(x::Vec{N, T}, ptr::Union{Ptr{T}, LLVMPtr{T}}, mask::Union{Nothing, Vec{N, Bool}}=nothing,
+@propagate_inbounds function vstore(x::Vec{N, T}, ptr::AnyPtr{T}, mask::Union{Nothing, Vec{N, Bool}}=nothing,
                        ::Val{Aligned}=Val(false), ::Val{Nontemporal}=Val(false)) where {N, T, Aligned, Nontemporal}
     if mask === nothing
         Intrinsics.store(x.data, ptr, Val(Aligned), Val(Nontemporal))
@@ -102,7 +102,7 @@ end
     end
 end
 
-@inline vstorec(x::Vec{N, T}, ptr::Union{Ptr{T}, LLVMPtr{T}}, mask::Vec{N, Bool}) where {N, T} =
+@inline vstorec(x::Vec{N, T}, ptr::AnyPtr{T}, mask::Vec{N, Bool}) where {N, T} =
     Intrinsics.maskedcompressstore(x.data, ptr, mask.data)
 
 @propagate_inbounds function vstorec(x::Vec{N, T}, a::FastContiguousArray{T,1},
@@ -149,7 +149,7 @@ end
 # Have to be careful with optional arguments and @boundscheck,
 # see https://github.com/JuliaLang/julia/issues/30411,
 # therefore use @propagate_inbounds
-@inline vgather(ptrs::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}},
+@inline vgather(ptrs::Vec{N,<:AnyPtr{T}},
                  mask::Vec{N,Bool}=one(Vec{N,Bool}),
                  ::Val{Aligned}=Val(false)) where {N, T<:ScalarTypes, Aligned} =
     return Vec(Intrinsics.maskedgather(ptrs.data, mask.data))
@@ -168,17 +168,17 @@ end
 end
 @propagate_inbounds vgathera(a, idx, mask) = vgather(a, idx, mask, Val(true))
 @propagate_inbounds vgathera(a, idx::Vec{N}) where {N} = vgather(a, idx, one(Vec{N,Bool}), Val(true))
-@propagate_inbounds vgathera(ptrs::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}, mask::Vec{N,Bool}) where {N,T} = vgather(ptrs, mask, Val(true))
-@propagate_inbounds vgathera(ptrs::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}) where {N,T} = vgather(ptrs, one(Vec{N,Bool}), Val(true))
+@propagate_inbounds vgathera(ptrs::Vec{N,<:AnyPtr{T}}, mask::Vec{N,Bool}) where {N,T} = vgather(ptrs, mask, Val(true))
+@propagate_inbounds vgathera(ptrs::Vec{N,<:AnyPtr{T}}) where {N,T} = vgather(ptrs, one(Vec{N,Bool}), Val(true))
 
 @propagate_inbounds Base.getindex(a::FastContiguousArray{T,1}, idx::Vec{N,<:Integer}) where {N,T} =
     vgather(a, idx)
 
 
-@propagate_inbounds vscatter(x::Vec{N,T}, ptrs::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}},
+@propagate_inbounds vscatter(x::Vec{N,T}, ptrs::Vec{N,<:AnyPtr{T}},
                              mask::Vec{N,Bool}, ::Val{Aligned}=Val(false)) where {N, T<:ScalarTypes, Aligned} =
     Intrinsics.maskedscatter(x.data, ptrs.data, mask.data)
-@inline vscatter(x::Vec{N,T}, ptrs::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}},
+@inline vscatter(x::Vec{N,T}, ptrs::Vec{N,<:AnyPtr{T}},
                  ::Nothing, aligned::Val=Val(false)) where {N, T<:ScalarTypes} =
     vscatter(x, ptrs, one(Vec{N, Bool}), aligned)
 @propagate_inbounds function vscatter(x::Vec{N,T}, a::FastContiguousArray{T,1}, idx::Vec{N, <:Integer},
@@ -195,8 +195,8 @@ end
 end
 @propagate_inbounds vscattera(x, a, idx, mask) = vscatter(x, a, idx, mask, Val(true))
 @propagate_inbounds vscattera(x, a, idx::Vec{N}) where {N}  = vscatter(x, a, idx, one(Vec{N,Bool}), Val(true))
-@propagate_inbounds vscattera(x::Vec{N,T}, ptrs::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}, mask::Vec{N,Bool}) where {N,T} = vscatter(x, ptrs, mask, Val(true))
-@propagate_inbounds vscattera(x::Vec{N,T}, ptrs::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}) where {N,T} = vscatter(x, ptrs, one(Vec{N,Bool}), Val(true))
+@propagate_inbounds vscattera(x::Vec{N,T}, ptrs::Vec{N,<:AnyPtr{T}}, mask::Vec{N,Bool}) where {N,T} = vscatter(x, ptrs, mask, Val(true))
+@propagate_inbounds vscattera(x::Vec{N,T}, ptrs::Vec{N,<:AnyPtr{T}}) where {N,T} = vscatter(x, ptrs, one(Vec{N,Bool}), Val(true))
 
 @propagate_inbounds Base.setindex!(a::FastContiguousArray{T,1}, v::Vec{N,T}, idx::Vec{N,<:Integer}) where {N, T} =
     vscatter(v, a, idx)

--- a/src/simdvec.jl
+++ b/src/simdvec.jl
@@ -316,12 +316,12 @@ _signed(::Type{Float64}) = Int64
 
 # Pointer arithmetic
 # Cast pointer to Int and back
-@inline Base.:+(x::Vec{N,Ptr{T}}, y::Vec{N,<:IntegerTypes}) where {N,T} = convert(typeof(x), convert(Vec{N,UInt}, x) + y)
-@inline Base.:-(x::Vec{N,Ptr{T}}, y::Vec{N,<:IntegerTypes}) where {N,T} = convert(typeof(x), convert(Vec{N,UInt}, x) - y)
-@inline Base.:+(x::Ptr{T}, y::Vec{N,<:IntegerTypes}) where {N,T} = convert(Vec{N,typeof(x)}, UInt(x) + y)
-@inline Base.:-(x::Ptr{T}, y::Vec{N,<:IntegerTypes}) where {N,T} = convert(Vec{N,typeof(x)}, UInt(x) - y)
-@inline Base.:+(x::Vec{N,Ptr{T}}, y::IntegerTypes) where {N,T} = convert(typeof(x), convert(Vec{N,UInt}, x) + y)
-@inline Base.:-(x::Vec{N,Ptr{T}}, y::IntegerTypes) where {N,T} = convert(typeof(x), convert(Vec{N,UInt}, x) - y)
+@inline Base.:+(x::Vec{N,Ptr{T}}, y::Vec{N,<:IntegerTypes}) where {N,T} = convert(Vec{N,Ptr{T}}, convert(Vec{N,UInt}, x) + y)
+@inline Base.:-(x::Vec{N,Ptr{T}}, y::Vec{N,<:IntegerTypes}) where {N,T} = convert(Vec{N,Ptr{T}}, convert(Vec{N,UInt}, x) - y)
+@inline Base.:+(x::Ptr{T}, y::Vec{N,<:IntegerTypes}) where {N,T} = convert(Vec{N,Ptr{T}}, convert(UInt, x) + y)
+@inline Base.:-(x::Ptr{T}, y::Vec{N,<:IntegerTypes}) where {N,T} = convert(Vec{N,Ptr{T}}, convert(UInt, x) - y)
+@inline Base.:+(x::Vec{N,Ptr{T}}, y::IntegerTypes) where {N,T} = convert(Vec{N,Ptr{T}}, convert(Vec{N,UInt}, x) + y)
+@inline Base.:-(x::Vec{N,Ptr{T}}, y::IntegerTypes) where {N,T} = convert(Vec{N,Ptr{T}}, convert(Vec{N,UInt}, x) - y)
 
 # use gep
 @inline Base.:+(x::Vec{N,LLVMPtr{T, AS}}, y::Vec{N,<:IntegerTypes}) where {N,T,AS} = Vec(Intrinsics.add_ptr(x.data, y.data))

--- a/src/simdvec.jl
+++ b/src/simdvec.jl
@@ -316,20 +316,20 @@ _signed(::Type{Float64}) = Int64
 
 # Pointer arithmetic
 # Cast pointer to Int and back
-@inline Base.:+(x::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}, y::Vec{N,<:IntegerTypes}) where {N,T} = convert(typeof(x), convert(Vec{N,UInt}, x) + y)
-@inline Base.:-(x::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}, y::Vec{N,<:IntegerTypes}) where {N,T} = convert(typeof(x), convert(Vec{N,UInt}, x) - y)
-@inline Base.:+(x::Union{Ptr{T}, LLVMPtr{T}}, y::Vec{N,<:IntegerTypes}) where {N,T} = convert(Vec{N,typeof(x)}, UInt(x) + y)
-@inline Base.:-(x::Union{Ptr{T}, LLVMPtr{T}}, y::Vec{N,<:IntegerTypes}) where {N,T} = convert(Vec{N,typeof(x)}, UInt(x) - y)
-@inline Base.:+(x::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}, y::IntegerTypes) where {N,T} = convert(typeof(x), convert(Vec{N,UInt}, x) + y)
-@inline Base.:-(x::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}, y::IntegerTypes) where {N,T} = convert(typeof(x), convert(Vec{N,UInt}, x) - y)
+@inline Base.:+(x::Vec{N,<:AnyPtr{T}}, y::Vec{N,<:IntegerTypes}) where {N,T} = convert(typeof(x), convert(Vec{N,UInt}, x) + y)
+@inline Base.:-(x::Vec{N,<:AnyPtr{T}}, y::Vec{N,<:IntegerTypes}) where {N,T} = convert(typeof(x), convert(Vec{N,UInt}, x) - y)
+@inline Base.:+(x::AnyPtr{T}, y::Vec{N,<:IntegerTypes}) where {N,T} = convert(Vec{N,typeof(x)}, UInt(x) + y)
+@inline Base.:-(x::AnyPtr{T}, y::Vec{N,<:IntegerTypes}) where {N,T} = convert(Vec{N,typeof(x)}, UInt(x) - y)
+@inline Base.:+(x::Vec{N,<:AnyPtr{T}}, y::IntegerTypes) where {N,T} = convert(typeof(x), convert(Vec{N,UInt}, x) + y)
+@inline Base.:-(x::Vec{N,<:AnyPtr{T}}, y::IntegerTypes) where {N,T} = convert(typeof(x), convert(Vec{N,UInt}, x) - y)
 
-@inline Base.:+(y::Vec{N,<:IntegerTypes}, x::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}) where {N,T} = x + y
-@inline Base.:+(y::Vec{N,<:IntegerTypes}, x::Union{Ptr{T}, LLVMPtr{T}}) where {N,T} = x + y
-@inline Base.:+(y::IntegerTypes, x::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}) where {N,T} = x + y
+@inline Base.:+(y::Vec{N,<:IntegerTypes}, x::Vec{N,<:AnyPtr{T}}) where {N,T} = x + y
+@inline Base.:+(y::Vec{N,<:IntegerTypes}, x::AnyPtr{T}) where {N,T} = x + y
+@inline Base.:+(y::IntegerTypes, x::Vec{N,<:AnyPtr{T}}) where {N,T} = x + y
 
-@inline Base.:-(x::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}, y::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}) where {N,T} = convert(Vec{N,Int}, x) - convert(Vec{N,Int}, y)
-@inline Base.:-(x::Union{Ptr{T}, LLVMPtr{T}}, y::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}) where {N,T} = UInt(x) % Int - convert(Vec{N,Int}, y)
-@inline Base.:-(x::Vec{N,<:Union{Ptr{T}, LLVMPtr{T}}}, y::Union{Ptr{T}, LLVMPtr{T}}) where {N,T} = convert(Vec{N,Int}, x) - UInt(y) % Int
+@inline Base.:-(x::Vec{N,<:AnyPtr{T}}, y::Vec{N,<:AnyPtr{T}}) where {N,T} = convert(Vec{N,Int}, x) - convert(Vec{N,Int}, y)
+@inline Base.:-(x::AnyPtr{T}, y::Vec{N,<:AnyPtr{T}}) where {N,T} = UInt(x) % Int - convert(Vec{N,Int}, y)
+@inline Base.:-(x::Vec{N,<:AnyPtr{T}}, y::AnyPtr{T}) where {N,T} = convert(Vec{N,Int}, x) - UInt(y) % Int
 
 # Bitshifts
 # See https://github.com/JuliaLang/julia/blob/7426625b5c07b0d93110293246089a259a0a677d/src/intrinsics.cpp#L1179-L1196

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,3 @@
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
-OpenCL = "08131aa3-fb12-5dee-8b74-c09406e224a2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-pocl_jll = "627d6b7a-bbe6-5189-83e7-98cc0a5aeadd"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+OpenCL = "08131aa3-fb12-5dee-8b74-c09406e224a2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+pocl_jll = "627d6b7a-bbe6-5189-83e7-98cc0a5aeadd"

--- a/test/opencl.jl
+++ b/test/opencl.jl
@@ -1,0 +1,227 @@
+using KernelAbstractions, OpenCL, pocl_jll
+using SIMD
+using Test
+
+const backend = OpenCLBackend()
+
+@testset "OpenCL SIMD Load/Store Tests" begin
+    @testset "Basic load/store operations" begin
+        @kernel function load_store_kernel!(a, b)
+            i = 4 * (@index(Global) - 1) + 1
+            xs = @inbounds vload(Vec{4, Float32}, b, i)
+            @inbounds vstore(xs + Vec{4, Float32}(1f0), a, i)
+        end
+
+        b = KernelAbstractions.zeros(backend, Float32, 1024)
+        a = similar(b)
+        load_store_kernel!(backend)(a, b; ndrange = 1024 ÷ 4)
+        @test all(==(1f0), a)
+    end
+
+    @testset "Multiple data types load/store" begin
+        # Test Int32 vectors
+        @kernel function load_store_int32_kernel!(a, b)
+            i = 4 * (@index(Global) - 1) + 1
+            xs = @inbounds vload(Vec{4, Int32}, b, i)
+            @inbounds vstore(xs + Vec{4, Int32}(10), a, i)
+        end
+
+        b_int = KernelAbstractions.zeros(backend, Int32, 256)
+        fill!(b_int, 5)
+        a_int = similar(b_int)
+        load_store_int32_kernel!(backend)(a_int, b_int; ndrange = 256 ÷ 4)
+        @test all(==(15), a_int)
+
+        # Test different vector sizes for Float32
+        @kernel function load_store_float32_vec8_kernel!(a, b)
+            i = 8 * (@index(Global) - 1) + 1
+            xs = @inbounds vload(Vec{8, Float32}, b, i)
+            @inbounds vstore(xs * Vec{8, Float32}(2f0), a, i)
+        end
+
+        b_f32 = KernelAbstractions.ones(backend, Float32, 512)
+        a_f32 = similar(b_f32)
+        load_store_float32_vec8_kernel!(backend)(a_f32, b_f32; ndrange = 512 ÷ 8)
+        @test all(==(2f0), a_f32)
+    end
+
+    @testset "Aligned load/store operations" begin
+        @kernel function aligned_load_store_kernel!(a, b)
+            i = 4 * (@index(Global) - 1) + 1
+            xs = @inbounds vloada(Vec{4, Float32}, b, i)
+            @inbounds vstorea(xs + Vec{4, Float32}(3f0), a, i)
+        end
+
+        b = KernelAbstractions.zeros(backend, Float32, 1024)
+        fill!(b, 2f0)
+        a = similar(b)
+        aligned_load_store_kernel!(backend)(a, b; ndrange = 1024 ÷ 4)
+        @test all(==(5f0), a)
+    end
+
+    @testset "Non-temporal load/store operations" begin
+        @kernel function nontemporal_load_store_kernel!(a, b)
+            i = 4 * (@index(Global) - 1) + 1
+            xs = @inbounds vloadnt(Vec{4, Float32}, b, i)
+            @inbounds vstorent(xs * Vec{4, Float32}(1.5f0), a, i)
+        end
+
+        b = KernelAbstractions.ones(backend, Float32, 512)
+        fill!(b, 4f0)
+        a = similar(b)
+        nontemporal_load_store_kernel!(backend)(a, b; ndrange = 512 ÷ 4)
+        @test all(==(6f0), a)
+    end
+
+    #@testset "Masked load/store operations" begin
+    #    function masked_load_store_kernel!(a, b, masks_buf)
+    #        idx = get_global_id()
+    #        i = 4 * (idx - 1) + 1
+
+    #        # Create mask from buffer (convert to bool)
+    #        mask = Vec{4, Bool}((
+    #            masks_buf[i] > 0,
+    #            masks_buf[i+1] > 0,
+    #            masks_buf[i+2] > 0,
+    #            masks_buf[i+3] > 0
+    #        ))
+
+    #        xs = @inbounds vload(Vec{4, Float32}, b, i, mask)
+    #        result = xs + Vec{4, Float32}(10f0)
+    #        @inbounds vstore(result, a, i, mask)
+    #        return
+    #    end
+
+    #    n = 256
+    #    b = KernelAbstractions.ones(backend, Float32, n)
+    #    a = KernelAbstractions.zeros(backend, Float32, n)
+
+    #    # Create mask pattern: alternating true/false
+    #    mask_data = zeros(Int32, n)
+    #    for i in 1:n
+    #        mask_data[i] = i % 2
+    #    end
+    #    masks_buf = KernelAbstractions.zeros(backend, Int32, n)
+    #    copyto!(masks_buf, mask_data)
+
+    #    @opencl global_size = n ÷ 4 backend = :khronos extensions = ["SPV_INTEL_masked_gather_scatter"] validate = false masked_load_store_kernel!(a, b, masks_buf)
+
+    #    a_host = Array(a)
+    #    # Check that masked elements were updated, unmasked remain zero
+    #    for i in 1:n
+    #        if i % 2 == 1  # mask was true
+    #            @test a_host[i] == 11f0
+    #        else  # mask was false
+    #            @test a_host[i] == 0f0
+    #        end
+    #    end
+    #end
+
+    @testset "Gather/scatter operations" begin
+        function gather_scatter_kernel!(a, b, indices_buf)
+            idx = get_global_id()
+            base_i = 4 * (idx - 1) + 1
+
+            # Load indices
+            indices = Vec{4, Int32}((
+                indices_buf[base_i],
+                indices_buf[base_i + 1],
+                indices_buf[base_i + 2],
+                indices_buf[base_i + 3]
+            ))
+
+            # Gather from b using indices
+            gathered = @inbounds vgather(b, indices)
+
+            # Process and scatter back to a
+            result = gathered * Vec{4, Float32}(2f0)
+            @inbounds vscatter(result, a, indices)
+            return
+        end
+
+        n = 128
+        b = KernelAbstractions.zeros(backend, Float32, n)
+        # Fill b with indices as values for easy verification
+        b_data = Float32.(1:n)
+        copyto!(b, b_data)
+
+        a = KernelAbstractions.zeros(backend, Float32, n)
+
+        # Create gather indices (1-based)
+        indices_data = Int32[]
+        for i in 1:4:(n-3)
+            # Gather in reverse order for testing
+            append!(indices_data, [i+3, i+2, i+1, i])
+        end
+        indices_buf = KernelAbstractions.zeros(backend, Int32, length(indices_data))
+        copyto!(indices_buf, indices_data)
+
+        @opencl global_size = length(indices_data) ÷ 4 backend = :khronos extensions = ["SPV_INTEL_masked_gather_scatter"] validate = false gather_scatter_kernel!(a, b, indices_buf)
+
+        a_host = Array(a)
+        # Verify scattered results
+        for (i, original_idx) in enumerate(indices_data)
+            expected = Float32(original_idx) * 2f0
+            @test a_host[original_idx] == expected
+        end
+    end
+
+    @testset "Masked gather/scatter operations" begin
+        function masked_gather_scatter_kernel!(a, b, indices_buf, masks_buf)
+            idx = get_global_id()
+            base_i = 4 * (idx - 1) + 1
+
+            # Load indices and mask
+            indices = Vec{4, Int32}((
+                indices_buf[base_i],
+                indices_buf[base_i + 1],
+                indices_buf[base_i + 2],
+                indices_buf[base_i + 3]
+            ))
+
+            mask = Vec{4, Bool}((
+                masks_buf[base_i] > 0,
+                masks_buf[base_i + 1] > 0,
+                masks_buf[base_i + 2] > 0,
+                masks_buf[base_i + 3] > 0
+            ))
+
+            # Masked gather
+            gathered = @inbounds vgather(b, indices, mask)
+
+            # Process and masked scatter
+            result = gathered + Vec{4, Float32}(100f0)
+            @inbounds vscatter(result, a, indices, mask)
+            return
+        end
+
+        n = 64
+        b = KernelAbstractions.zeros(backend, Float32, n)
+        b_data = Float32.(1:n) .* 10f0
+        copyto!(b, b_data)
+
+        a = KernelAbstractions.zeros(backend, Float32, n)
+
+        # Create indices and masks
+        indices_data = Int32.(1:n)
+        indices_buf = KernelAbstractions.zeros(backend, Int32, n)
+        copyto!(indices_buf, indices_data)
+
+        # Checkerboard mask pattern
+        mask_data = [i % 2 for i in 1:n]
+        masks_buf = KernelAbstractions.zeros(backend, Int32, n)
+        copyto!(masks_buf, mask_data)
+
+        @opencl global_size = n ÷ 4 backend = :khronos extensions = ["SPV_INTEL_masked_gather_scatter"] validate = false masked_gather_scatter_kernel!(a, b, indices_buf, masks_buf)
+
+        a_host = Array(a)
+        for i in 1:n
+            if i % 2 == 1  # mask was true
+                expected = Float32(i) * 10f0 + 100f0
+                @test a_host[i] == expected
+            else  # mask was false, should remain zero
+                @test a_host[i] == 0f0
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1019,6 +1019,10 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
         end
     end
 
-include("opencl.jl")
+if parse(Bool, get(ENV, "TEST_OPENCL", "true"))
+    include("opencl.jl")
+else
+    @info "Skipping OpenCL tests"
+end
 
 # end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1019,4 +1019,6 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
         end
     end
 
+include("opencl.jl")
+
 # end


### PR DESCRIPTION
and add some OpenCL tests. The gather/scatter tests will require a small
upstream change to allow disabling SPIRV validation, since the validator
doesn't seem to understand the `SPV_INTEL_masked_gather_scatter`
extension.

addresses https://github.com/eschnett/SIMD.jl/issues/80

written with help from Copilot