### PR TITLE
Implement `Base.setindex!(arr, v::Number, idx::VecOrVecRange, I...)`

### DIFF
--- a/src/arrayops.jl
+++ b/src/arrayops.jl
@@ -201,6 +201,7 @@ end
 @propagate_inbounds Base.setindex!(a::FastContiguousArray{T,1}, v::Vec{N,T}, idx::Vec{N,<:Integer}) where {N, T} =
     vscatter(v, a, idx)
 
+@propagate_inbounds Base.setindex!(a::FastContiguousArray{T,1}, s::Number, idx::Vec{N,<:Integer}) where {N, T} = Base.setindex!(a, Vec{N,T}(s), idx)
 
 export VecRange
 
@@ -331,3 +332,10 @@ Base.@propagate_inbounds function Base.setindex!(
     vscatter(v, ptrs, mask)
     return arr
 end
+
+Base.@propagate_inbounds function Base.setindex!(
+        arr::ContiguousArray{T}, s::Number, idx::Union{<:Vec{N,<:Integer},<:VecRange{N}},
+        args::Vararg{Union{Integer,Vec{N,Bool}}}) where {N,T}
+    return Base.setindex!(arr, Vec{N,T}(s), idx, args...)
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -837,6 +837,36 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
                 end
             end
         end
+
+        let a = zeros(Float32,8), M = zeros(Float64,8,2)
+
+            a[Vec{4,Int}((8,4,3,1))] = 1
+            @test a == Float32[1, 0, 1, 1, 0, 0, 0, 1]
+
+            a[VecRange{4}(5)] = 2
+            @test a == Float32[1, 0, 1, 1, 2, 2, 2, 2]
+
+            M[Vec{4,Int}((8,4,3,1)), 2] = 1
+            @test M == Float64[0 1
+                               0 0
+                               0 1
+                               0 1
+                               0 0
+                               0 0
+                               0 0
+                               0 1]
+
+            M[VecRange{4}(5), 2] = 2
+            @test M == Float64[0 1
+                               0 0
+                               0 1
+                               0 1
+                               0 2
+                               0 2
+                               0 2
+                               0 2]
+        end
+
     end
 
     @testset "Real-world examples" begin


### PR DESCRIPTION
This PR allows one to use scalar values (`::Number`s) when "set"-indexing an array using `Vec` or `VecRange`.

This is useful to prevent indexing errors with highly generic functions.
For example, a generic function that applies some operations elementwise with explicit vectorization:

```
function apply_simd_op(out::AbstractVector, op::F, args::Vararg{AbstractVector, N}) where {F<:Function, N}
    l = length(out)
    @assert rem(l, 8) == 0
    lane = SIMD.VecRange{8}(0)
    @inbounds for i in 1:8:l
        lpi = lane + i
        out[lpi] = op(map(x -> getindex(x, lpi), args)...)
    end
    return out
end
```

Calling something like `apply_simd_op(out, (x,y,z)->(x*x - y*z + 2), arr1, arr2, arr3)` works, but a simple `apply_simd_op(out, x->1, arr1)` currently produces an error.
With this PR the code would work as intended.

I encountered this issue in a much more involved "real" case (actually a test for an edge case).

Fixes #156 