### PR TITLE
Add `previx_load` and `prefix_store!` as optimized `load` with mask etc 

### DIFF
--- a/src/LLVM_intrinsics.jl
+++ b/src/LLVM_intrinsics.jl
@@ -559,15 +559,21 @@ elsewhere). Substantially faster than the generic
 `N` element-wise comparisons against a constant index vector.
 """
 @generated function prefix_mask(::Val{N}, n::Int64) where {N}
-    fn = "llvm.get.active.lane.mask.v$(N)i1.i64"
+    @assert N in (1,2,4,8,16,32,64) "prefix_mask: N must be a power of 2 ≤ 64"
     ir = """
-        declare <$N x i1> @$fn(i64, i64)
         define <$N x i8> @entry(i64 %n) #0 {
         top:
-            %m1 = call <$N x i1> @$fn(i64 0, i64 %n)
+            %clamped = call i64 @llvm.umin.i64(i64 %n, i64 $N)
+            %shift_amt = sub i64 64, %clamped         ; ← was `sub i64 $N, %clamped`
+            %ones = sub i64 0, 1
+            %bits64 = call i64 @llvm.fshr.i64(i64 0, i64 %ones, i64 %shift_amt)
+            %bits = trunc i64 %bits64 to i$N
+            %m1 = bitcast i$N %bits to <$N x i1>
             %m8 = zext <$N x i1> %m1 to <$N x i8>
             ret <$N x i8> %m8
         }
+        declare i64 @llvm.umin.i64(i64, i64)
+        declare i64 @llvm.fshr.i64(i64, i64, i64)
         attributes #0 = { alwaysinline }
         """
     quote

--- a/src/LLVM_intrinsics.jl
+++ b/src/LLVM_intrinsics.jl
@@ -544,6 +544,40 @@ end
     )
 end
 
+"""
+    prefix_mask(::Val{N}, n::Integer) -> Vec{N,Bool}
+
+Return a `Vec{N,Bool}` whose first `min(max(n, 0), N)` lanes are `true`
+and the remaining lanes are `false`. The canonical "vectorized-loop tail"
+mask: lane `i` (0-indexed) is `true` iff `i < n`.
+
+Lowers to LLVM's `llvm.get.active.lane.mask` intrinsic, which targets
+hand-tuned mask-building instructions on each backend (`kshift` chains
+on AVX-512, `whilelt`-style instructions on ARM SVE, scalar fallback
+elsewhere). Substantially faster than the generic
+`Vec{N,Bool}(ntuple(i -> i <= n, Val(N)))` lowering, which expands to
+`N` element-wise comparisons against a constant index vector.
+"""
+@generated function prefix_mask(::Val{N}, n::Int64) where {N}
+    fn = "llvm.get.active.lane.mask.v$(N)i1.i64"
+    ir = """
+        declare <$N x i1> @$fn(i64, i64)
+        define <$N x i8> @entry(i64 %n) #0 {
+        top:
+            %m1 = call <$N x i1> @$fn(i64 0, i64 %n)
+            %m8 = zext <$N x i1> %m1 to <$N x i8>
+            ret <$N x i8> %m8
+        }
+        attributes #0 = { alwaysinline }
+        """
+    quote
+        $(Expr(:meta, :inline))
+        nt = Base.llvmcall(($ir, "entry"), NTuple{$N, VecElement{Bool}},
+                            Tuple{Int64}, n)
+        Vec{$N,Bool}(nt)
+    end
+end
+
 @generated function store(x::LVec{N, T}, ptr::Ptr{T},
                           ::Val{Al}=Val(false), ::Val{Te}=Val(false)) where {N, T, Al, Te}
     s = """

--- a/src/arrayops.jl
+++ b/src/arrayops.jl
@@ -115,6 +115,29 @@ end
     return a
 end
 
+"""
+    vload_prefix(::Type{Vec{N,T}}, ptr::Ptr{T}, n::Integer) -> Vec{N,T}
+
+Load `min(max(n, 0), N)` consecutive elements of `T` from `ptr` into the
+first lanes of a `Vec{N,T}`; remaining lanes are zero. Equivalent to
+`vload(Vec{N,T}, ptr, prefix_mask(Val(N), n))` but composed into one
+call site.
+"""
+@inline function vload_prefix(::Type{Vec{N,T}}, ptr::Ptr{T}, n::Integer) where {N,T}
+    vload(Vec{N,T}, ptr, prefix_mask(Val(N), Int64(n)))
+end
+
+"""
+    vstore_prefix!(v::Vec{N,T}, ptr::Ptr{T}, n::Integer) -> Nothing
+
+Store the first `min(max(n, 0), N)` lanes of `v` to `ptr`; remaining
+lanes are not written. Equivalent to
+`vstore(v, ptr, prefix_mask(Val(N), n))` but composed into one call site.
+"""
+@inline function vstore_prefix!(v::Vec{N,T}, ptr::Ptr{T}, n::Integer) where {N,T}
+    vstore(v, ptr, prefix_mask(Val(N), Int64(n)))
+end
+
 function valloc(::Type{T}, N::Int, sz::Int) where T
     @assert N > 0
     @assert sz >= 0


### PR DESCRIPTION
This is helpful for generating slightly better code. PR generated with claude help, but I've reviewed it to ensure reasonability:
```
julia> @inline lanewise_mask(::Val{N}, n::Int64) where {N} =
           Vec{N,Bool}(ntuple(i -> i <= n, Val(N)))
lanewise_mask (generic function with 1 method)

julia> @inline vload_via_lanewise(::Type{Vec{N,T}}, p::Ptr{T}, n::Int64) where {N,T} =
           vload(Vec{N,T}, p, lanewise_mask(Val(N), n))
vload_via_lanewise (generic function with 1 method)

julia> @inline vstore_via_lanewise!(v::Vec{N,T}, p::Ptr{T}, n::Int64) where {N,T} =
           vstore(v, p, lanewise_mask(Val(N), n))
vstore_via_lanewise! (generic function with 1 method)

julia> @code_native debuginfo=:none syntax=:intel prefix_mask(Val(W), Int64(5))
	.text
	.file	"prefix_mask"
	.section	.rodata.cst16,"aM",@progbits,16
	.p2align	4, 0x0                          # -- Begin function julia_prefix_mask_10453
.LCPI0_0:
	.zero	16,1
	.section	.ltext,"axl",@progbits
	.globl	julia_prefix_mask_10453
	.p2align	4, 0x90
	.type	julia_prefix_mask_10453,@function
julia_prefix_mask_10453:                # @julia_prefix_mask_10453
; Function Signature: prefix_mask(Base.Val{16}, Int64)
# %bb.0:                                # %top
	#DEBUG_VALUE: prefix_mask:n <- $rsi
	push	rbp
	mov	rbp, rsp
	cmp	rsi, 16
	mov	ecx, 16
	cmovb	rcx, rsi
	neg	ecx
	xor	eax, eax
	mov	rdx, -1
                                        # kill: def $cl killed $cl killed $rcx
	shrd	rdx, rax, cl
	mov	rax, rdi
	kmovd	k1, edx
	movabs	rcx, offset .LCPI0_0
	vmovdqu8	xmm0 {k1} {z}, xmmword ptr [rcx]
	vmovdqa	xmmword ptr [rdi], xmm0
	pop	rbp
	ret
.Lfunc_end0:
	.size	julia_prefix_mask_10453, .Lfunc_end0-julia_prefix_mask_10453
                                        # -- End function
	.type	".L+SIMD.Vec#10455",@object     # @"+SIMD.Vec#10455"
	.section	.lrodata,"al",@progbits
	.p2align	3, 0x0
".L+SIMD.Vec#10455":
	.quad	".L+SIMD.Vec#10455.jit"
	.size	".L+SIMD.Vec#10455", 8

.set ".L+SIMD.Vec#10455.jit", 123450746584720
	.size	".L+SIMD.Vec#10455.jit", 8
	.section	".note.GNU-stack","",@progbits

julia> @code_native debuginfo=:none syntax=:intel lanewise_mask(Val(W), Int64(5))

	.text
	.file	"lanewise_mask"
	.section	.rodata,"a",@progbits
	.p2align	6, 0x0                          # -- Begin function julia_lanewise_mask_10459
.LCPI0_0:
	.quad	0                               # 0x0
	.quad	1                               # 0x1
	.quad	2                               # 0x2
	.quad	3                               # 0x3
	.quad	4                               # 0x4
	.quad	5                               # 0x5
	.quad	6                               # 0x6
	.quad	7                               # 0x7
.LCPI0_1:
	.quad	8                               # 0x8
	.quad	9                               # 0x9
	.quad	10                              # 0xa
	.quad	11                              # 0xb
	.quad	12                              # 0xc
	.quad	13                              # 0xd
	.quad	14                              # 0xe
	.quad	15                              # 0xf
	.section	.rodata.cst16,"aM",@progbits,16
	.p2align	4, 0x0
.LCPI0_2:
	.zero	16,1
	.section	.ltext,"axl",@progbits
	.globl	julia_lanewise_mask_10459
	.p2align	4, 0x90
	.type	julia_lanewise_mask_10459,@function
julia_lanewise_mask_10459:              # @julia_lanewise_mask_10459
; Function Signature: lanewise_mask(Base.Val{16}, Int64)
# %bb.0:                                # %top
	#DEBUG_VALUE: lanewise_mask:n <- $rsi
	push	rbp
	mov	rbp, rsp
	mov	rax, rdi
	vpbroadcastq	zmm0, rsi
	movabs	rcx, offset .LCPI0_0
	vpcmpgtq	k0, zmm0, zmmword ptr [rcx]
	movabs	rcx, offset .LCPI0_1
	vpcmpgtq	k1, zmm0, zmmword ptr [rcx]
	kunpckbw	k1, k1, k0
	movabs	rcx, offset .LCPI0_2
	vmovdqu8	xmm0 {k1} {z}, xmmword ptr [rcx]
	vmovdqa	xmmword ptr [rdi], xmm0
	pop	rbp
	vzeroupper
	ret
.Lfunc_end0:
	.size	julia_lanewise_mask_10459, .Lfunc_end0-julia_lanewise_mask_10459
                                        # -- End function
	.type	".L+SIMD.Vec#10461",@object     # @"+SIMD.Vec#10461"
	.section	.lrodata,"al",@progbits
	.p2align	3, 0x0
".L+SIMD.Vec#10461":
	.quad	".L+SIMD.Vec#10461.jit"
	.size	".L+SIMD.Vec#10461", 8

.set ".L+SIMD.Vec#10461.jit", 123450746584720
	.size	".L+SIMD.Vec#10461.jit", 8
	.section	".note.GNU-stack","",@progbits

julia>  @code_native debuginfo=:none syntax=:intel vload_prefix(Vec{W,Float32}, Ptr{Float32}(0), Int64(5))
	.text
	.file	"vload_prefix"
	.section	.ltext,"axl",@progbits
	.globl	julia_vload_prefix_10462        # -- Begin function julia_vload_prefix_10462
	.p2align	4, 0x90
	.type	julia_vload_prefix_10462,@function
julia_vload_prefix_10462:               # @julia_vload_prefix_10462
; Function Signature: vload_prefix(Type{SIMD.Vec{16, Float32}}, Ptr{Float32}, Int64)
# %bb.0:                                # %top
	#DEBUG_VALUE: vload_prefix:ptr <- $rsi
	#DEBUG_VALUE: vload_prefix:n <- $rdx
	push	rbp
	mov	rbp, rsp
	cmp	rdx, 16
	mov	ecx, 16
	cmovb	rcx, rdx
	neg	ecx
	xor	eax, eax
	mov	rdx, -1
                                        # kill: def $cl killed $cl killed $rcx
	shrd	rdx, rax, cl
	mov	rax, rdi
	kmovd	k1, edx
	vmovups	zmm0 {k1} {z}, zmmword ptr [rsi]
	vmovups	zmmword ptr [rdi], zmm0
	pop	rbp
	vzeroupper
	ret
.Lfunc_end0:
	.size	julia_vload_prefix_10462, .Lfunc_end0-julia_vload_prefix_10462
                                        # -- End function
	.type	".L+SIMD.Vec#10464",@object     # @"+SIMD.Vec#10464"
	.section	.lrodata,"al",@progbits
	.p2align	3, 0x0
".L+SIMD.Vec#10464":
	.quad	".L+SIMD.Vec#10464.jit"
	.size	".L+SIMD.Vec#10464", 8

.set ".L+SIMD.Vec#10464.jit", 123450787514512
	.size	".L+SIMD.Vec#10464.jit", 8
	.section	".note.GNU-stack","",@progbits

julia> @code_native debuginfo=:none syntax=:intel vload_via_lanewise(Vec{W,Float32}, Ptr{Float32}(0), Int64(5))

	.text
	.file	"vload_via_lanewise"
	.section	.rodata,"a",@progbits
	.p2align	6, 0x0                          # -- Begin function julia_vload_via_lanewise_10470
.LCPI0_0:
	.quad	0                               # 0x0
	.quad	1                               # 0x1
	.quad	2                               # 0x2
	.quad	3                               # 0x3
	.quad	4                               # 0x4
	.quad	5                               # 0x5
	.quad	6                               # 0x6
	.quad	7                               # 0x7
.LCPI0_1:
	.quad	8                               # 0x8
	.quad	9                               # 0x9
	.quad	10                              # 0xa
	.quad	11                              # 0xb
	.quad	12                              # 0xc
	.quad	13                              # 0xd
	.quad	14                              # 0xe
	.quad	15                              # 0xf
	.section	.ltext,"axl",@progbits
	.globl	julia_vload_via_lanewise_10470
	.p2align	4, 0x90
	.type	julia_vload_via_lanewise_10470,@function
julia_vload_via_lanewise_10470:         # @julia_vload_via_lanewise_10470
; Function Signature: vload_via_lanewise(Type{SIMD.Vec{16, Float32}}, Ptr{Float32}, Int64)
# %bb.0:                                # %top
	#DEBUG_VALUE: vload_via_lanewise:p <- $rsi
	#DEBUG_VALUE: vload_via_lanewise:n <- $rdx
	push	rbp
	mov	rbp, rsp
	vpbroadcastq	zmm0, rdx
	movabs	rax, offset .LCPI0_0
	vpcmpgtq	k0, zmm0, zmmword ptr [rax]
	movabs	rax, offset .LCPI0_1
	vpcmpgtq	k1, zmm0, zmmword ptr [rax]
	mov	rax, rdi
	kunpckbw	k1, k1, k0
	vmovups	zmm0 {k1} {z}, zmmword ptr [rsi]
	vmovups	zmmword ptr [rdi], zmm0
	pop	rbp
	vzeroupper
	ret
.Lfunc_end0:
	.size	julia_vload_via_lanewise_10470, .Lfunc_end0-julia_vload_via_lanewise_10470
                                        # -- End function
	.type	".L+SIMD.Vec#10472",@object     # @"+SIMD.Vec#10472"
	.section	.lrodata,"al",@progbits
	.p2align	3, 0x0
".L+SIMD.Vec#10472":
	.quad	".L+SIMD.Vec#10472.jit"
	.size	".L+SIMD.Vec#10472", 8

.set ".L+SIMD.Vec#10472.jit", 123450787514512
	.size	".L+SIMD.Vec#10472.jit", 8
	.section	".note.GNU-stack","",@progbits

julia> @code_native debuginfo=:none syntax=:intel vstore_prefix!(Vec{W,Float32}(0f0), Ptr{Float32}(0), Int64(5))

	.text
	.file	"vstore_prefix!"
	.section	.ltext,"axl",@progbits
	.globl	"julia_vstore_prefix!_10476"    # -- Begin function julia_vstore_prefix!_10476
	.p2align	4, 0x90
	.type	"julia_vstore_prefix!_10476",@function
"julia_vstore_prefix!_10476":           # @"julia_vstore_prefix!_10476"
; Function Signature: vstore_prefix!(SIMD.Vec{16, Float32}, Ptr{Float32}, Int64)
# %bb.0:                                # %top
	#DEBUG_VALUE: vstore_prefix!:v <- [$rdi+0]
	#DEBUG_VALUE: vstore_prefix!:ptr <- $rsi
	#DEBUG_VALUE: vstore_prefix!:n <- $rdx
	push	rbp
	mov	rbp, rsp
	cmp	rdx, 16
	mov	ecx, 16
	cmovb	rcx, rdx
	neg	ecx
	xor	eax, eax
	mov	rdx, -1
                                        # kill: def $cl killed $cl killed $rcx
	shrd	rdx, rax, cl
	kmovd	k1, edx
	vmovups	zmm0, zmmword ptr [rdi]
	vmovups	zmmword ptr [rsi] {k1}, zmm0
	pop	rbp
	vzeroupper
	ret
.Lfunc_end0:
	.size	"julia_vstore_prefix!_10476", .Lfunc_end0-"julia_vstore_prefix!_10476"
                                        # -- End function
	.section	".note.GNU-stack","",@progbits

julia> @code_native debuginfo=:none syntax=:intel vstore_via_lanewise!(Vec{W,Float32}(0f0), Ptr{Float32}(0), Int64(5))

	.text
	.file	"vstore_via_lanewise!"
	.section	.rodata,"a",@progbits
	.p2align	6, 0x0                          # -- Begin function julia_vstore_via_lanewise!_10483
.LCPI0_0:
	.quad	0                               # 0x0
	.quad	1                               # 0x1
	.quad	2                               # 0x2
	.quad	3                               # 0x3
	.quad	4                               # 0x4
	.quad	5                               # 0x5
	.quad	6                               # 0x6
	.quad	7                               # 0x7
.LCPI0_1:
	.quad	8                               # 0x8
	.quad	9                               # 0x9
	.quad	10                              # 0xa
	.quad	11                              # 0xb
	.quad	12                              # 0xc
	.quad	13                              # 0xd
	.quad	14                              # 0xe
	.quad	15                              # 0xf
	.section	.ltext,"axl",@progbits
	.globl	"julia_vstore_via_lanewise!_10483"
	.p2align	4, 0x90
	.type	"julia_vstore_via_lanewise!_10483",@function
"julia_vstore_via_lanewise!_10483":     # @"julia_vstore_via_lanewise!_10483"
; Function Signature: vstore_via_lanewise!(SIMD.Vec{16, Float32}, Ptr{Float32}, Int64)
# %bb.0:                                # %top
	#DEBUG_VALUE: vstore_via_lanewise!:v <- [$rdi+0]
	#DEBUG_VALUE: vstore_via_lanewise!:p <- $rsi
	#DEBUG_VALUE: vstore_via_lanewise!:n <- $rdx
	push	rbp
	mov	rbp, rsp
	vpbroadcastq	zmm0, rdx
	movabs	rax, offset .LCPI0_0
	vpcmpgtq	k0, zmm0, zmmword ptr [rax]
	movabs	rax, offset .LCPI0_1
	vpcmpgtq	k1, zmm0, zmmword ptr [rax]
	kunpckbw	k1, k1, k0
	vmovups	zmm0, zmmword ptr [rdi]
	vmovups	zmmword ptr [rsi] {k1}, zmm0
	pop	rbp
	vzeroupper
	ret
.Lfunc_end0:
	.size	"julia_vstore_via_lanewise!_10483", .Lfunc_end0-"julia_vstore_via_lanewise!_10483"
                                        # -- End function
	.section	".note.GNU-stack","",@progbits
	```
```
I found this while trying to write a fast SIMD.jl only matmul