### PR TITLE
Overload `Base.ifelse(x::Vec{N,Bool}, y, z)` -> `SIMD.vifelse` for Julia >=v1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ The SIMD package provides the usual arithmetic and logical operations for SIMD v
 
 `+ - * / % ^ ! ~ & | $ << >> >>> == != < <= > >=`
 
-`abs ceil copysign cos div eps exp exp2 flipsign floor fma inv isfinite isinf isnan issubnormal log log10 log2 muladd rem round sign signbit sin sqrt trunc vifelse`
+`abs ceil copysign cos div eps exp exp2 flipsign floor fma ifelse¹ inv isfinite isinf isnan issubnormal log log10 log2 muladd rem round sign signbit sin sqrt trunc vifelse`
 
-(Currently missing: `exponent ldexp significand`, many trigonometric functions)
+(Currently missing: `exponent ldexp significand`, many trigonometric functions)  
+¹ Supported on Julia v1.8 and above. For compatibility with lower versions use `vifelse` instead.
 
 These operators and functions are always applied element-wise, i.e. they are applied to each element in parallel, yielding again a SIMD vector as result. This means that e.g. multiplying two vectors yields a vector, and comparing two vectors yields a vector of booleans. This behaviour might seem strange and slightly unusual, but corresponds to the machine instructions provided by the hardware. It is also what is usually needed to vectorize loops.
 

--- a/src/simdvec.jl
+++ b/src/simdvec.jl
@@ -437,6 +437,10 @@ end
 @inline vifelse(v::Vec{N, Bool}, v1::T2, v2::Vec{N, T}) where {N, T, T2 <:ScalarTypes} = vifelse(v, Vec{N, T}(v1), v2)
 @inline vifelse(v::Vec{N, Bool}, v1::Vec{N, T}, v2::T2) where {N, T, T2 <:ScalarTypes} = vifelse(v, v1, Vec{N, T}(v2))
 
+@static if VERSION >= v"1.8"
+    @inline Base.ifelse(v::Vec{N, Bool}, v1, v2) where {N} = vifelse(v, v1, v2)
+end
+
 # fma, muladd and vectorization of these
 for (op, llvmop) in [(:fma, Intrinsics.fma), (:muladd, Intrinsics.fmuladd)]
     @eval begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,7 +141,12 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
         end
 
         global vifelsebool(x,y,z) = vifelse(x>=typeof(x)(0),y,z)
-        for op in (vifelsebool, muladd)
+        @static if VERSION >= v"1.8"
+            global ifelsebool(x,y,z) = ifelse(x>=typeof(x)(0),y,z)
+        else
+            global ifelsebool(x,y,z) = vifelsebool(x,y,z)
+        end
+        for op in (vifelsebool, ifelsebool, muladd)
             @test Tuple(op(V8I32(v8i32), V8I32(v8i32b), V8I32(v8i32c))) ===
                 map(op, v8i32, v8i32b, v8i32c)
         end
@@ -292,7 +297,7 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
         @test Tuple(V4F64(v4f64)^2) === v4f64.^2
         @test Tuple(V4F64(v4f64)^3) === v4f64.^3
 
-        for op in (fma, vifelsebool, muladd)
+        for op in (fma, vifelsebool, ifelsebool, muladd)
             @test Tuple(op(V4F64(v4f64), V4F64(v4f64b), V4F64(v4f64c))) ===
                 map(op, v4f64, v4f64b, v4f64c)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,13 +140,12 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
             @test Tuple(op(V8I32(v8i32), V8I32(v8i32b))) === map(op, v8i32, v8i32b)
         end
 
-        global vifelsebool(x,y,z) = vifelse(x>=typeof(x)(0),y,z)
         @static if VERSION >= v"1.8"
-            global ifelsebool(x,y,z) = ifelse(x>=typeof(x)(0),y,z)
+            global ifelsebool(x,y,z) = ifelse(x>=zero(x),y,z)
         else
-            global ifelsebool(x,y,z) = vifelsebool(x,y,z)
+            global ifelsebool(x,y,z) = vifelse(x>=zero(x),y,z)
         end
-        for op in (vifelsebool, ifelsebool, muladd)
+        for op in (ifelsebool, muladd)
             @test Tuple(op(V8I32(v8i32), V8I32(v8i32b), V8I32(v8i32c))) ===
                 map(op, v8i32, v8i32b, v8i32c)
         end
@@ -297,7 +296,7 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
         @test Tuple(V4F64(v4f64)^2) === v4f64.^2
         @test Tuple(V4F64(v4f64)^3) === v4f64.^3
 
-        for op in (fma, vifelsebool, ifelsebool, muladd)
+        for op in (fma, ifelsebool, muladd)
             @test Tuple(op(V4F64(v4f64), V4F64(v4f64b), V4F64(v4f64c))) ===
                 map(op, v4f64, v4f64b, v4f64c)
         end


### PR DESCRIPTION
Fixes #162 