### PR TITLE
Implement `Base.eps(v)` for `v::Vec{N,<:FloatingTypes}` and `v::Type{Vec{N,<:FloatingTypes}}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The SIMD package provides the usual arithmetic and logical operations for SIMD v
 
 `+ - * / % ^ ! ~ & | $ << >> >>> == != < <= > >=`
 
-`abs ceil copysign cos div exp exp2 flipsign floor fma inv isfinite isinf isnan issubnormal log log10 log2 muladd rem round sign signbit sin sqrt trunc vifelse`
+`abs ceil copysign cos div eps exp exp2 flipsign floor fma inv isfinite isinf isnan issubnormal log log10 log2 muladd rem round sign signbit sin sqrt trunc vifelse`
 
 (Currently missing: `exponent ldexp significand`, many trigonometric functions)
 

--- a/src/simdvec.jl
+++ b/src/simdvec.jl
@@ -515,3 +515,12 @@ end
 @inline Base.conj(v::Vec{N, T}) where {N, T<:ScalarTypes} = v
 @inline Base.angle(v::Vec{N, T}) where {N, T <: FloatingTypes} = vifelse(signbit(v), Vec{N, T}(T(pi)), zero(v))
 @inline Base.imag(v::Vec{N, T}) where {N, T <: ScalarTypes} = zero(v)
+
+#Same implementation as in Base for IEEEFloats
+@inline function Base.eps(x::Vec{N, T}) where {N, T<:FloatingTypes}
+    TU = _unsigned(T)
+    y = reinterpret(Vec{N, T}, reinterpret(Vec{N, TU}, x) ⊻ one(TU))
+    return abs(x - y)
+end
+
+@inline Base.eps(::Type{Vec{N, T}}) where {N, T<:FloatingTypes} = Vec{N, T}(eps(T))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -306,13 +306,22 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
         @test occursin("@llvm.powi.v4f64", ir)
 
         #tests for eps implementation
-        let v = V4F64((1, -1000, 100000, -1000000000))
+        @test eps(V4F64) === V4F64(eps(Float64))
+        for v in (
+                V4F64((1, -1000, 100000, -1000000000)),
+                V4F64((0.0, prevfloat(1.0), 1.0, nextfloat(1.0))),
+                V4F64((-1.5, prevfloat(1.5), 1.5, nextfloat(1.5)))
+            )
             ev = eps(v)
             for i in 1:4
                 @test ev[i] === eps(v[i])
             end
-
-            @test eps(V4F64) === V4F64(eps(Float64))
+        end
+        #Sanity check
+        let v1 = V4F64((prevfloat(1.0, 2), prevfloat(1.0), 1.0, nextfloat(1.0))),
+                v2 = V4F64((prevfloat(1.5, 2), prevfloat(1.5), 1.5, nextfloat(1.5)))
+            @test v1 + eps(v1) === V4F64((prevfloat(1.0), 1.0, nextfloat(1.0), nextfloat(1.0,2)))
+            @test v2 + eps(v2) === V4F64((prevfloat(1.5), 1.5, nextfloat(1.5), nextfloat(1.5,2)))
         end
 
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -304,6 +304,17 @@ llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...))
         # See: https://github.com/eschnett/SIMD.jl/pull/43
         ir = llvm_ir(^, (V4F64(v4f64), Int32(2)))
         @test occursin("@llvm.powi.v4f64", ir)
+
+        #tests for eps implementation
+        let v = V4F64((1, -1000, 100000, -1000000000))
+            ev = eps(v)
+            for i in 1:4
+                @test ev[i] === eps(v[i])
+            end
+
+            @test eps(V4F64) === V4F64(eps(Float64))
+        end
+
     end
 
     @testset "Type promotion" begin


### PR DESCRIPTION
This PR implements the `Base.eps` function for `Vec`s of Floats.
The algorithm used is the same as from `Base`, with minor adaptation for `Vec`s.